### PR TITLE
Fixed namespace-component merging

### DIFF
--- a/.changeset/new-pears-explode.md
+++ b/.changeset/new-pears-explode.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-solid': patch
+---
+
+Made it so that the plugin gets executed after "esbuild"

--- a/src/index.ts
+++ b/src/index.ts
@@ -185,7 +185,6 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
 
   return {
     name: 'solid',
-    enforce: 'pre',
 
     async config(userConfig, { command }) {
       // We inject the dev mode only if the user explicitly wants it or if we are in dev (serve) mode
@@ -195,6 +194,10 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
 
       if (!userConfig.resolve) userConfig.resolve = {};
       userConfig.resolve.alias = normalizeAliases(userConfig.resolve && userConfig.resolve.alias);
+
+      // Forces "esbuild" to preserve JSX so that we can handle it here
+      // If "esbuild" is not being used I don't need to change anything
+      if (userConfig.esbuild) userConfig.esbuild.jsx ??= 'preserve';
 
       const solidPkgsConfig = await crawlFrameworkPkgs({
         viteUserConfig: userConfig,

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,8 +196,9 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
       userConfig.resolve.alias = normalizeAliases(userConfig.resolve && userConfig.resolve.alias);
 
       // Forces "esbuild" to preserve JSX so that we can handle it here
-      // If "esbuild" is not being used I don't need to change anything
-      if (userConfig.esbuild) userConfig.esbuild.jsx ??= 'preserve';
+      // If "esbuild" is not being used, we don't need to change anything
+      if (userConfig.esbuild !== false)
+        userConfig.esbuild = { jsx: 'preserve', ...userConfig.esbuild };
 
       const solidPkgsConfig = await crawlFrameworkPkgs({
         viteUserConfig: userConfig,


### PR DESCRIPTION
Made it so that the plugin gets executed AFTER "esbuild", thus making namespaces no longer an issue of the plugin

---
Fixes #145 