### PR TITLE
ci: declare workflow-level `contents: read` on e2e and vitest

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   e2e-tests:
     name: "E2E tests"

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   vitest:
     name: 'Vitest'


### PR DESCRIPTION
Both workflows run vitest / e2e tests. No GitHub API writes, so workflow-level `contents: read` is the right cap.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.