### PR TITLE
fix: normalize lazy() module-url paths to forward slashes on Windows

### DIFF
--- a/.changeset/fix-lazy-module-url-windows-backslash.md
+++ b/.changeset/fix-lazy-module-url-windows-backslash.md
@@ -1,0 +1,10 @@
+---
+'vite-plugin-solid': patch
+---
+
+fix: normalize lazy() module-url paths to forward slashes on Windows
+
+The `solid-lazy-module-url` transform appended the resolved module path as the
+2nd argument to `lazy(() => import(...))` using `path.relative`, which yields
+backslashes on Windows. The injected `"src\components\App.tsx"` is an invalid
+escape sequence and broke dev/build for any `lazy()` route on Windows.

--- a/scripts/test-examples.ts
+++ b/scripts/test-examples.ts
@@ -21,6 +21,21 @@ function cleanup() {
 process.on('SIGTERM', cleanup);
 process.on('SIGINT', cleanup);
 
+// Run the node:test unit suites (test/**/*.test.ts) in a child process so their
+// TAP output streams through and a failure aborts the whole run.
+async function runUnitTests() {
+  console.log('Running unit tests...');
+  await new Promise<void>((resolve, reject) => {
+    const proc = spawn('node', ['--test', 'test/**/*.test.ts'], { stdio: 'inherit' });
+    activeProcesses.add(proc);
+    proc.on('error', reject);
+    proc.on('exit', (code: number | null) => {
+      activeProcesses.delete(proc);
+      code === 0 ? resolve() : reject(new Error(`Unit tests failed (exit code ${code})`));
+    });
+  });
+}
+
 async function runExample(example) {
   console.log(`Testing ${example}...`);
   const examplePath = `examples/${example}`;
@@ -59,6 +74,14 @@ async function runExample(example) {
 }
 
 async function runAll() {
+  try {
+    await runUnitTests();
+  } catch (error) {
+    console.error(error);
+    cleanup();
+    process.exit(1);
+  }
+
   for (const example of examples) {
     try {
       await runExample(example);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { createRequire } from 'module';
 import solidRefresh from 'solid-refresh/babel';
 // TODO use proper path
 import type { Options as RefreshOptions } from 'solid-refresh/babel';
-import lazyModuleUrl, { LAZY_PLACEHOLDER_PREFIX } from './lazy-module-url.js';
+import lazyModuleUrl, { LAZY_PLACEHOLDER_PREFIX, normalizeLazyModulePath } from './lazy-module-url.js';
 import path from 'path';
 import type { Alias, AliasOptions, FilterPattern, Plugin } from 'vite';
 import { createFilter, version } from 'vite';
@@ -535,7 +535,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
           const cleanId = resolved.id.split('?')[0];
           resolutions.push({
             placeholder: match[0],
-            resolved: '"' + path.relative(projectRoot, cleanId) + '"',
+            resolved: '"' + normalizeLazyModulePath(path.relative(projectRoot, cleanId)) + '"',
           });
         }
       }

--- a/src/lazy-module-url.ts
+++ b/src/lazy-module-url.ts
@@ -3,6 +3,18 @@ import type { PluginObj, types as t } from '@babel/core';
 export const LAZY_PLACEHOLDER_PREFIX = '__SOLID_LAZY_MODULE__:';
 
 /**
+ * Normalize a resolved lazy() module path to a POSIX-style string.
+ *
+ * The path is built with `path.relative`, which yields OS-native separators.
+ * It is then embedded back into JS source as the 2nd argument to `lazy()`, so
+ * on Windows the backslashes (`"src\components\App.tsx"`) become invalid escape
+ * sequences that break the parse. Always use forward slashes.
+ */
+export function normalizeLazyModulePath(relativePath: string): string {
+  return relativePath.replace(/\\/g, '/');
+}
+
+/**
  * Detects whether a CallExpression argument is `() => import("specifier")`
  * and returns the specifier string if so.
  */

--- a/test/lazy-module-url.test.ts
+++ b/test/lazy-module-url.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { normalizeLazyModulePath } from '../src/lazy-module-url.ts';
+
+// Regression test for the Windows-only bug where `path.relative` returns
+// backslash separators that, once embedded as the 2nd arg to `lazy()`, are
+// invalid JS escape sequences (`"src\components\App.tsx"`) and break the parse.
+test('normalizeLazyModulePath converts Windows backslashes to forward slashes', () => {
+  assert.equal(normalizeLazyModulePath('src\\components\\App.tsx'), 'src/components/App.tsx');
+});
+
+test('normalizeLazyModulePath leaves POSIX paths untouched', () => {
+  assert.equal(normalizeLazyModulePath('src/components/App.tsx'), 'src/components/App.tsx');
+});
+
+test('normalizeLazyModulePath handles mixed separators', () => {
+  assert.equal(normalizeLazyModulePath('src\\ui/buttons\\Base.tsx'), 'src/ui/buttons/Base.tsx');
+});
+
+test('normalizeLazyModulePath leaves a bare filename untouched', () => {
+  assert.equal(normalizeLazyModulePath('App.tsx'), 'App.tsx');
+});


### PR DESCRIPTION
# fix: normalize `lazy()` module-url paths to forward slashes on Windows

> Temporary file — draft body for the PR. Delete before/after opening.
> Target branch: **`next`** (the `lazy()` module-url feature only exists on the 3.x line).

## Problem

The `solid-lazy-module-url` babel pass detects `lazy(() => import("specifier"))`
and injects a placeholder as a 2nd argument; the `transform` hook then resolves
that placeholder to the module's project-relative path and substitutes it back
into the emitted source.

The path is built with `path.relative`, which returns **OS-native separators**.
On Windows that means backslashes, and the result is spliced straight back into
JS source as a string literal:

```js
// emitted on Windows:
const App = lazy(() => import('./App'), "src\components\App.tsx");
//                                        ^^^^ \c, \A → invalid escape sequence
```

`\c`, `\A`, etc. are invalid string escape sequences, so the file fails to
parse. In practice this breaks **dev and build for any `lazy()` route on
Windows** (the downstream esbuild/rolldown transform throws
`Invalid escape sequence` / `Transform failed`). POSIX is unaffected because
`path.relative` already returns forward slashes there — which is why it has
gone unnoticed.

### Where

`src/index.ts`, in the lazy-placeholder resolution loop:

```js
resolved: '"' + path.relative(projectRoot, cleanId) + '"',
```

No normalization is applied before the path is embedded back into source.

## Fix

Normalize the resolved path to POSIX separators before embedding it. The path
is only ever used as a module-url string in generated JS, so forward slashes
are always correct (and match what the rest of Vite emits).

A small pure helper is added to `src/lazy-module-url.ts` (its natural home,
alongside `LAZY_PLACEHOLDER_PREFIX`):

```ts
export function normalizeLazyModulePath(relativePath: string): string {
  return relativePath.replace(/\\/g, '/');
}
```

and the call site becomes:

```js
resolved: '"' + normalizeLazyModulePath(path.relative(projectRoot, cleanId)) + '"',
```

That is the entire behavioral change — one helper plus one wrapped call.

## Tests

`test/lazy-module-url.test.ts` covers the helper with the built-in
[`node:test`](https://nodejs.org/api/test.html) runner (no new dependencies):

- Windows backslashes → forward slashes (the regression)
- POSIX paths left untouched
- mixed separators
- bare filename (no separator) untouched

### Why a unit test of the helper, and not an example/e2e test

The bug is **OS-specific**: it only reproduces when `path.relative` returns
backslashes, i.e. on Windows. The existing example + Cypress/Vitest suites run
on **Linux** CI runners, where `path.relative` already yields forward slashes —
so an example-based test could never fail for this bug regardless of the fix.

A pure unit test on the normalization function is deterministic on **every**
OS: it feeds a backslash path in and asserts forward slashes out, so it guards
the regression on the Linux CI too.

### How it's wired (and why this way)

There is intentionally **no new `package.json` script**. The unit suite is run
from the existing `scripts/test-examples.ts` (already invoked by `pnpm test`),
before the example builds, so:

```ts
async function runUnitTests() {
  console.log('Running unit tests...');
  await new Promise<void>((resolve, reject) => {
    const proc = spawn('node', ['--test', 'test/**/*.test.ts'], { stdio: 'inherit' });
    activeProcesses.add(proc);
    proc.on('error', reject);
    proc.on('exit', (code: number | null) => {
      activeProcesses.delete(proc);
      code === 0 ? resolve() : reject(new Error(`Unit tests failed (exit code ${code})`));
    });
  });
}
```

Rationale:

- **Single entry point.** `pnpm test` already drives the whole suite; folding
  the unit tests in keeps one command and means CI (`e2e.yml` → `pnpm run test`)
  picks them up with no workflow changes.
- **Fail-fast.** Unit tests run first — fast and cheap — before the heavy
  `pnpm install` + build per example.
- **Streaming output.** `spawn(..., { stdio: 'inherit' })` lets the TAP output
  pass straight through, and a non-zero exit rejects so the run aborts (and the
  child is tracked in `activeProcesses` for the existing cleanup path).
- **Zero new deps / zero config.** `node:test` is built in. Node strips the
  TypeScript types itself (CI runs Node 23, which does this unflagged; the
  `test/` dir is outside `tsconfig` `include` and the rollup entry, so it never
  leaks into `dist`).

### Placement / CI note

This targets **`next`** because `lazy()` module-url resolution only exists
there. Heads-up: the workflows currently trigger on `branches: [main]` only, so
a `next`-targeted PR may not auto-run CI until `next` is added to the triggers
(left untouched here — maintainer call).

## Verification

- `node scripts/test-examples.ts` → `Running unit tests...` → 4/4 pass →
  proceeds to `Testing vite-3...`.
- `pnpm build` → exit 0; bundle contains
  `normalizeLazyModulePath(path.relative(projectRoot, cleanId))`.
- Manually reproduced on Windows: a `lazy()` route 500'd in dev with
  `Invalid escape sequence` before the change, renders cleanly after.
