### PR TITLE
fix downstream lazy entry classification

### DIFF
--- a/.changeset/clean-lazy-entries.md
+++ b/.changeset/clean-lazy-entries.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-solid': patch
+---
+
+Reclassify emitted lazy facade chunks as dynamic entries in the raw output bundle so downstream plugins do not mistake them for application entries.

--- a/src/index.ts
+++ b/src/index.ts
@@ -487,6 +487,10 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
       }
     },
 
+    generateBundle(_options, bundle) {
+      normalizeEmittedLazyEntries(bundle);
+    },
+
     load(id) {
       if (id === runtimePublicPath) return runtimeCode;
       if (id === RESOLVED_VIRTUAL_MANIFEST_ID) {


### PR DESCRIPTION
## Summary

Reclassify emitted `lazy()` facade chunks in the raw Rollup output bundle so downstream plugins do not mistake them for application entry points.

## Problem

SSR-mode client builds emit dynamically imported project modules as explicit facade chunks. This ensures each lazy module receives a stable manifest entry, but Rollup can mark those emitted chunks as `isEntry: true` even though they are dynamically imported by another chunk.

`vite-plugin-solid` already corrects this classification when loading the serialized Vite manifest. However, plugins that inspect the raw output bundle during `generateBundle` run before that correction and can observe multiple apparent application entries.

For example, TanStack Start's client manifest plugin failed on Linux with:

```text
Error: multiple entries detected: assets/index-*.js assets/routes-*.js
```

The `index` chunk is the actual client entry, while the `routes` chunk is an emitted lazy facade.

## Fix

Run the existing `normalizeEmittedLazyEntries` helper from `generateBundle` as well as when loading the serialized manifest.

This changes chunks that are both:

- marked as entries; and
- dynamically imported by another chunk

from `isEntry` to `isDynamicEntry` before downstream output hooks inspect the bundle. The real client entry remains unchanged.

## Verification

- `pnpm build`
- Confirmed the generated ESM and CJS packages compile successfully
