### PR TITLE
fix: make lazy facade entry reclassification effective under rolldown-vite

### DIFF
--- a/.changeset/lazy-entry-rolldown-reclassify.md
+++ b/.changeset/lazy-entry-rolldown-reclassify.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-solid': patch
+---
+
+Reclassify emitted lazy facade chunks by assigning `isEntry = false` instead of deleting the property. Under rolldown-vite (Vite 8), bundle chunks in `generateBundle` are proxies whose set trap syncs assignments back to the native bundle, while a delete is swallowed by the proxy's read cache — so the reclassification silently no-oped and downstream plugins (e.g. TanStack Start's manifest plugin) still saw every lazy facade chunk as an application entry, failing builds with "multiple entries detected".

--- a/src/index.ts
+++ b/src/index.ts
@@ -268,7 +268,11 @@ function normalizeEmittedLazyEntries(manifest: Record<string, any>) {
   for (const key of dynamicKeys) {
     const entry = manifest[key];
     if (entry && entry.isEntry) {
-      delete entry.isEntry;
+      // Assign rather than delete: rolldown-vite materializes bundle chunks
+      // as proxies whose set trap syncs changes back to the native bundle,
+      // while a delete is swallowed by the proxy's read cache and never
+      // reaches it (or downstream plugins).
+      entry.isEntry = false;
       entry.isDynamicEntry = true;
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -268,10 +268,6 @@ function normalizeEmittedLazyEntries(manifest: Record<string, any>) {
   for (const key of dynamicKeys) {
     const entry = manifest[key];
     if (entry && entry.isEntry) {
-      // Assign rather than delete: rolldown-vite materializes bundle chunks
-      // as proxies whose set trap syncs changes back to the native bundle,
-      // while a delete is swallowed by the proxy's read cache and never
-      // reaches it (or downstream plugins).
       entry.isEntry = false;
       entry.isDynamicEntry = true;
     }


### PR DESCRIPTION
## Problem

`normalizeEmittedLazyEntries` reclassifies the emitted lazy facade chunks (`isEntry` → `isDynamicEntry`) in `generateBundle` so that downstream plugins don't mistake them for application entries. It does this with `delete entry.isEntry` — which works on Rollup's plain bundle objects, but silently no-ops under rolldown-vite (Vite 8).

Rolldown materializes each chunk in the `generateBundle` bundle as a proxy over native data: property **assignment** is trapped, cached, and synced back to the native bundle after the hook returns, but a **delete** is not trapped at the chunk level — it falls through to the throwaway JS target while the proxy's read cache keeps serving the previously read `isEntry: true`. The mutation never reaches the native bundle, so it isn't even visible later in the same hook, let alone to downstream plugins.

Observed impact: every TanStack Start + Solid app on Vite 8 fails its client build with `multiple entries detected` — TanStack Start's manifest plugin runs after this plugin's `generateBundle`, sees all lazy facade chunks still flagged `isEntry`, and can't identify the real client entry. Instrumenting the current code during such a build shows `reclassified=63` yet 64 entry-flagged chunks remain afterwards.

## Fix

Assign `entry.isEntry = false` instead of deleting the property. On plain objects (Rollup bundles, and the parsed `manifest.json` this helper also normalizes) the behavior is identical for every truthiness check; under rolldown the assignment propagates correctly.

## Verification

- With this change applied to the 3.0.0-next.8 dist, a previously failing TanStack Start solid e2e app builds successfully and only the real client entry remains `isEntry`; reverting just this line reproduces the `multiple entries detected` failure.
- `pnpm build` (rollup + tsc) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)