### PR TITLE
fix: reclassify lazy facades without importers

### DIFF
--- a/.changeset/lazy-entry-eliminated-importers.md
+++ b/.changeset/lazy-entry-eliminated-importers.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-solid': patch
+---
+
+Reclassify emitted lazy facade chunks even when their importers are eliminated from the final bundle. Emitted chunk references are now retained so lazy facades can be identified without relying on a surviving `dynamicImports` edge.

--- a/examples/vite-8/src/App.tsx
+++ b/examples/vite-8/src/App.tsx
@@ -1,7 +1,6 @@
 import { onSettled } from "solid-js";
 import { CounterProvider, useCounter } from "./CounterContext";
-
-const title = 'Counter';
+import { title } from './UnusedLazyImporter';
 
 function Count() {
   const counter = useCounter();

--- a/examples/vite-8/src/UnusedLazy.tsx
+++ b/examples/vite-8/src/UnusedLazy.tsx
@@ -1,0 +1,3 @@
+export default function UnusedLazy() {
+  return <p>This lazy component should be removed from the application.</p>;
+}

--- a/examples/vite-8/src/UnusedLazyImporter.ts
+++ b/examples/vite-8/src/UnusedLazyImporter.ts
@@ -1,0 +1,9 @@
+import { lazy } from 'solid-js';
+
+export const title = 'Counter';
+
+export class UnusedLazyImporter {
+  mount() {
+    return lazy(() => import('./UnusedLazy'));
+  }
+}

--- a/examples/vite-8/vite.config.ts
+++ b/examples/vite-8/vite.config.ts
@@ -3,6 +3,33 @@ import solidPlugin from 'vite-plugin-solid';
 
 export default defineConfig({
   plugins: [
-    solidPlugin({ compiler: 'native' }),
+    {
+      name: 'simulate-eliminated-lazy-importer',
+      enforce: 'pre',
+      generateBundle(_options, bundle) {
+        for (const output of Object.values(bundle)) {
+          if (output.type === 'chunk') {
+            output.dynamicImports = [];
+          }
+        }
+      },
+    },
+    solidPlugin({ compiler: 'native', ssr: true }),
+    {
+      name: 'assert-single-entry',
+      enforce: 'post',
+      generateBundle(_options, bundle) {
+        const entries = Object.values(bundle).filter(
+          (output) => output.type === 'chunk' && output.isEntry,
+        );
+        if (entries.length !== 1) {
+          throw new Error(
+            `Expected one entry chunk, received: ${entries
+              .map((entry) => entry.fileName)
+              .join(', ')}`,
+          );
+        }
+      },
+    },
   ],
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -310,6 +310,10 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
   // Driven from moduleParsed so it covers every lazy() target, including
   // import.meta.glob entries that never pass through the moduleUrl transform.
   const emittedLazyChunks = new Set<string>();
+  // Keep the emitted references because a lazy module's importer may be
+  // removed from the final bundle, leaving no dynamic-import edge to identify
+  // its facade chunk during generateBundle.
+  const emittedLazyChunkRefs: string[] = [];
 
   // Whether the current hook invocation belongs to a client (browser) build.
   // Builder-mode builds (e.g. SolidStart's nitro plugin) run the client and
@@ -557,7 +561,9 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
         if (!/\.[mc]?[tj]sx?$/i.test(cleanId)) continue;
         if (emittedLazyChunks.has(depId)) continue;
         emittedLazyChunks.add(depId);
-        this.emitFile({ type: 'chunk', id: depId, preserveSignature: 'exports-only' });
+        emittedLazyChunkRefs.push(
+          this.emitFile({ type: 'chunk', id: depId, preserveSignature: 'exports-only' }),
+        );
       }
     },
 
@@ -623,7 +629,22 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
       // serialized manifest read back later) so downstream plugins inspecting
       // the bundle don't mistake them for application entries. Must precede
       // the client asset map build, which keys off dynamic entries.
-      if (options.ssr) normalizeEmittedLazyEntries(bundle);
+      if (options.ssr) {
+        for (const ref of emittedLazyChunkRefs) {
+          let fileName: string;
+          try {
+            fileName = this.getFileName(ref);
+          } catch {
+            // Ignore references retained from a previous watch build.
+            continue;
+          }
+          const chunk = bundle[fileName];
+          if (!chunk || chunk.type !== 'chunk') continue;
+          chunk.isEntry = false;
+          chunk.isDynamicEntry = true;
+        }
+        normalizeEmittedLazyEntries(bundle);
+      }
       substituteClientManifest(bundle, buildClientAssetMap(bundle, projectRoot, base));
     },
 


### PR DESCRIPTION
## Summary

- retain references for chunks emitted from lazy targets
- reclassify those exact chunks even when tree-shaking removes their final dynamic-import edge
- add a Vite 8 regression fixture and patch changeset

## Reproduction

Removing the emitted-reference tracking reproduces TanStack Start’s `multiple entries detected` failure with `BaseTanStackRouterDevtoolsPanel` under Vite 8.0.14 and Rolldown 1.0.2. Restoring this change makes the identical Solid Start build pass while retaining both devtools chunks as dynamic entries.

## Verification

- `pnpm run build`
- `pnpm run check` (100/100)
- `cd examples/vite-8 && pnpm run build`
- TanStack Solid Start custom-basepath production build with Vite 8.0.14 and Rolldown 1.0.2

The Vite 8 browser suite currently fails before test collection because `@solidjs/testing-library@0.8.10` imports the removed Solid 1 `solid-js/web` path; this is unrelated to this change.