### PR TITLE
fix: send server environments their reload signal on hot update

### DIFF
--- a/.changeset/server-environments-reload.md
+++ b/.changeset/server-environments-reload.md
@@ -1,0 +1,7 @@
+---
+'vite-plugin-solid': patch
+---
+
+Send non-client server environments their own full-reload signal during hot
+updates. Environment-runner based servers now re-evaluate changed modules
+instead of serving stale SSR output, while client HMR remains unaffected.

--- a/src/index.ts
+++ b/src/index.ts
@@ -626,12 +626,21 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
       } as typeof hot.send;
     },
 
-    hotUpdate() {
+    hotUpdate({ modules }) {
       // solid-refresh only injects HMR boundaries into client modules, so
       // non-client environments have no accept handlers. Without this, Vite
       // would see no boundaries and send full-reload messages that race with
       // client-side HMR updates.
       if (this.environment.name !== 'client') {
+        // Returning [] also suppresses the signal environment-runner based
+        // servers (e.g. nitro's dev worker) rely on to re-evaluate modules,
+        // leaving SSR stale until a manual restart. Send the reload on this
+        // environment's own channel — for runner-based environments that is
+        // the runner, for the default ssr environment a no-op, and never the
+        // browser websocket, so client HMR stays free of full-reload races.
+        if (modules.length > 0) {
+          this.environment.hot.send({ type: 'full-reload' });
+        }
         return [];
       }
     },


### PR DESCRIPTION
## Problem

`hotUpdate` returns `[]` for every non-client environment. The intent (per the comment) is sound: solid-refresh only injects HMR boundaries into client modules, so letting Vite's propagation run in server environments dead-ends into `full-reload` messages that race client-side HMR.

But emptying the modules array also suppresses the only reload signal that **environment-runner based servers** rely on. With nitro's Vite integration (`nitro/vite`), SSR runs in a persistent module runner inside a dev worker — evaluated modules live until that environment's hot channel receives a `full-reload`. Vite's default dead-end propagation would send exactly that, but it never runs because the modules array arrives empty (and downstream plugins like nitro's own `hotUpdate` are blinded the same way, since Vite feeds each hook the previous hook's filtered array).

Net effect in a `vite-plugin-solid` + `nitro` app: edit any SSR-rendered module (every route component) → client updates via HMR, server keeps rendering the old module until a manual dev-server restart → hydration key/markup mismatches on the next load (unclaimed server nodes, and in our repro a `Cannot read properties of null (reading 'nextSibling')` crash during hydration).

Full investigation with traces: nitrojs/nitro#4472 (this plugin's role: [comment](https://github.com/nitrojs/nitro/issues/4472#issuecomment-5057441095)). The staleness also needs a nitro-side fix for its worker reload (nitrojs/nitro#4473) — but without this change, the reload is never even requested.

## Fix

Keep the suppression, but send `{ type: "full-reload" }` on the environment's **own** hot channel first (when the changed file has modules in that environment's graph):

- For runner-based environments (nitro's dev worker), the channel reaches the runner — SSR picks up the edit.
- For the default `ssr` environment, the channel is a no-op — nothing changes.
- It is never the browser websocket, so the client-HMR race the original code guards against stays suppressed.

## Verification

Reproduced and verified against a Solid 2 + `nitro/vite` playground (vite 8.0.10, vite-plugin-solid 3.0.0-next.15, nitro 3.0.260610-beta with the nitrojs/nitro#4473 fix applied):

- Before: editing a route component leaves SSR output byte-identical across reloads until the dev server restarts; hydration mismatches on reload.
- After (this patch alone, no userland workarounds): consecutive edits are reflected in SSR within ~2s each, hydration is clean, and client HMR still applies edits in place with page state preserved (no full browser reloads).

`pnpm build` (rollup + tsc) passes.
