### PR TITLE
feat(ssr): defer serving and build wiring to external servers

### DIFF
--- a/.changeset/turnkey-external-server.md
+++ b/.changeset/turnkey-external-server.md
@@ -1,0 +1,23 @@
+---
+'vite-plugin-solid': patch
+---
+
+Turnkey SSR: let an external server own serving and the build.
+
+- Configuring `environments.ssr.build.rollupOptions.input` now signals that a
+  server integration (nitro, a Cloudflare worker, a custom harness) owns the
+  server. Turnkey still resolves/generates the entries, emits
+  `virtual:solid-ssr-handler` and configures the client manifest, but stops
+  overriding the ssr build input, the `dist/*` outDirs and the `builder` flag,
+  and stops registering its dev HTML middleware. Previously the ssr input was
+  overwritten with the handler unconditionally, so the integration was left
+  with no server entry of its own — with nitro that means no renderer route is
+  registered and every page 404s in preview.
+- The entry graph's dev stylesheets are now also exposed on a dev-only
+  endpoint, and the generated handler fetches it when the caller passes no
+  `devHead`. Entry CSS is collected in the dev HTML middleware, which never
+  runs when something else serves, and the handler typically runs in another
+  runtime (a dev worker, workerd) that can reach neither Vite's module graph
+  nor the `globalThis` resolver registry — so dev SSR streamed unstyled markup
+  and flashed on load. Collection stays per-request, so HMR-edited CSS is
+  current.

--- a/src/ssr/index.ts
+++ b/src/ssr/index.ts
@@ -67,6 +67,9 @@ export interface SsrOptions {
 // Server-only turnkey request handler; also the server bundle's entry so a
 // production server is one import away from `Request -> Response`.
 const HANDLER_ID = 'virtual:solid-ssr-handler';
+// Dev-only endpoint serving the entry graph's compiled stylesheets, so a
+// handler running outside this process can still inline them (see below).
+const DEV_ENTRY_CSS_PATH = '/__solid_dev_entry_css';
 // Generated default entries / document shell. The `.tsx` suffix routes them
 // through the plugin's normal JSX transform (per-environment SSR/DOM
 // compile), exactly like user-authored entry files.
@@ -178,6 +181,7 @@ export function ssrServe(
   let root = process.cwd();
   let base = '/';
   let isBuild = false;
+  let externalServer = false;
   let entries: ResolvedEntries | undefined;
 
   function requireEntries(): ResolvedEntries {
@@ -344,7 +348,23 @@ export function ssrServe(
       const devHead =
         `<script>${devStylePatch}</script>` +
         `<script type="module" src="${joinBase(base, '/@vite/client')}"></script>`;
-      lines.push(``, `const DEV_HEAD = ${JSON.stringify(devHead)};`);
+      lines.push(
+        ``,
+        `const DEV_HEAD = ${JSON.stringify(devHead)};`,
+        ``,
+        // Fallback for callers that cannot collect the styles themselves:
+        // an external server's handler runs in its own runtime (a dev
+        // worker, workerd) with no access to this module graph, so it asks
+        // the dev server over HTTP. Per request, so HMR edits stay current.
+        `async function fetchDevEntryStyles(request) {`,
+        `  try {`,
+        `    const response = await fetch(new URL(${JSON.stringify(DEV_ENTRY_CSS_PATH)}, request.url));`,
+        `    return response.ok ? await response.text() : '';`,
+        `  } catch {`,
+        `    return '';`,
+        `  }`,
+        `}`,
+      );
     }
 
     lines.push(
@@ -421,6 +441,9 @@ export function ssrServe(
       isBuild
         ? `  const clientEntry = options.clientEntry || resolveClientEntry();`
         : `  const clientEntry = options.clientEntry || ${JSON.stringify(devClientEntryUrl())};`,
+      isBuild
+        ? `  const devHead = options.devHead;`
+        : `  const devHead = options.devHead !== undefined ? options.devHead : await fetchDevEntryStyles(request);`,
       `  return provideRequestEvent({ request, locals: {} }, async () => {`,
       `    let result = entry.render(request, { clientEntry, ...options.context });`,
       // renderToStream results are thenables whose then() waits for the
@@ -430,7 +453,7 @@ export function ssrServe(
       `      result = await result;`,
       `    }`,
       `    if (result instanceof Response) return result;`,
-      `    return htmlResponse(result, clientEntry, options.devHead, options.responseInit);`,
+      `    return htmlResponse(result, clientEntry, devHead, options.responseInit);`,
       `  });`,
       `}`,
     );
@@ -453,33 +476,51 @@ export function ssrServe(
         const scanEntries = entries.generated
           ? [entries.app!, ...(entries.document ? [entries.document] : [])]
           : [path.resolve(root, entries.entryClient)];
+        // A configured ssr input means an external server integration owns
+        // the server: it drives the build and serves requests, adapting
+        // `virtual:solid-ssr-handler` to its own entry contract. Turnkey then
+        // contributes only the entries, the handler and the client manifest —
+        // overriding the ssr input here would leave that integration without a
+        // server entry, and its own build/serving pipeline in conflict.
+        externalServer = userConfig.environments?.ssr?.build?.rollupOptions?.input != null;
         return {
           // No index.html: dev must not fall back to SPA-serving one, and
           // the dep scanner needs explicit entries instead.
           appType: 'custom',
           ...(build
-            ? {
-                environments: {
-                  client: {
-                    build: {
-                      manifest: true,
-                      outDir: 'dist/client',
-                      rollupOptions: { input: clientInput },
+            ? externalServer
+              ? {
+                  environments: {
+                    client: {
+                      build: {
+                        manifest: true,
+                        rollupOptions: { input: clientInput },
+                      },
                     },
                   },
-                  ssr: {
-                    build: {
-                      outDir: 'dist/server',
-                      rollupOptions: { input: { server: HANDLER_ID } },
+                }
+              : {
+                  environments: {
+                    client: {
+                      build: {
+                        manifest: true,
+                        outDir: 'dist/client',
+                        rollupOptions: { input: clientInput },
+                      },
+                    },
+                    ssr: {
+                      build: {
+                        outDir: 'dist/server',
+                        rollupOptions: { input: { server: HANDLER_ID } },
+                      },
                     },
                   },
-                },
-                // Presence of `builder` makes a plain `vite build` build the
-                // whole app (all environments: client then ssr) on Vite 6+.
-                // A classic `vite build --ssr` invocation must stay a
-                // single-environment build, so it doesn't get the flag.
-                ...(env.isSsrBuild ? {} : { builder: {} }),
-              }
+                  // Presence of `builder` makes a plain `vite build` build the
+                  // whole app (all environments: client then ssr) on Vite 6+.
+                  // A classic `vite build --ssr` invocation must stay a
+                  // single-environment build, so it doesn't get the flag.
+                  ...(env.isSsrBuild ? {} : { builder: {} }),
+                }
             : {
                 optimizeDeps: { entries: scanEntries },
               }),
@@ -526,10 +567,28 @@ export function ssrServe(
             ? [app!, ...(document ? [document] : [])]
             : [path.resolve(root, entryServer)];
         };
+        // Exposed for handlers that run outside this process (see
+        // fetchDevEntryStyles in the generated handler); registered even when
+        // an external server owns HTML, which is exactly when it is needed.
+        server.middlewares.use(DEV_ENTRY_CSS_PATH, (_req, res) => {
+          collectDevStyles(server, styleRoots()).then(
+            (styles) => {
+              res.setHeader('content-type', 'text/html; charset=utf-8');
+              res.setHeader('cache-control', 'no-store');
+              res.end(styles.map(renderDevStyleTag).join(''));
+            },
+            () => {
+              res.statusCode = 500;
+              res.end('');
+            },
+          );
+        });
         // Post middleware: Vite's own middlewares (transforms, static, the
         // server-function endpoint) run first; whatever asks for HTML after
         // that gets the streamed SSR render.
         return () => {
+          // An external server (see `externalServer` above) serves HTML itself.
+          if (externalServer) return;
           server.middlewares.use((req, res, next) => {
             if (req.method !== 'GET') return next();
             const accept = req.headers.accept || '';


### PR DESCRIPTION
Turnkey SSR (`ssr: {}`) assumes it owns the server. When a server integration drives the build and serves requests — nitro, a Cloudflare worker, a custom harness — two assumptions break. Both showed up building a Solid 2 + nitro app against `3.0.0-next.16`.

## The ssr build input is overwritten unconditionally

`config()` always sets the ssr environment's input to `virtual:solid-ssr-handler` (plus `dist/*` outDirs and the `builder` flag). An integration that has its own server entry is left without one: nitro's `getEntry` finds nothing, so it registers **no renderer route** and every page 404s in preview — the built route table contains only the app's own API routes.

Now a user-configured `environments.ssr.build.rollupOptions.input` signals external ownership. Turnkey keeps doing the parts only it can do — resolving/generating entries, emitting the handler, configuring `manifest: true` and the client input — and leaves the ssr input, outDirs, `builder` flag and dev HTML middleware alone. Nothing changes for plain-Vite turnkey apps, which don't set that input.

## Dev entry CSS never reaches an external handler

Entry stylesheets are collected in the dev HTML middleware (`collectDevStyles` → `devHead` → `handleRequest`). That middleware doesn't run once something else serves, and the handler generally runs in a different runtime — a dev worker, workerd — which can reach neither Vite's module graph nor the `globalThis` resolver registry. Result: dev SSR streams unstyled markup and flashes on load. (I verified the registry genuinely isn't visible from nitro's dev worker.)

The styles are now also exposed on a dev-only endpoint, and the generated handler fetches it when the caller passes no `devHead`. Collection stays per-request so HMR-edited CSS is current, and the tags are the existing `renderDevStyleTag` output, so `devStylePatch` dedupes them against Vite's client injection exactly as before. Build output is untouched — the fetch only exists in the dev branch of the codegen.

## Testing

Against a Solid 2 + nitro app (`vite-plugin-solid@3.0.0-next.16`, `nitro@3.0.260610-beta`, Vite 8.0.10), generated entries with a small `src/ssr.ts` adapter exposing the handler as nitro's `{ fetch }` service:

- **Dev** — page 200, entry CSS server-rendered into `<head>` so first paint is styled; exactly one `<style>` tag in the DOM after hydration (Vite's client adopts the SSR'd twin); clean hydration, no console errors; server functions round-trip. Editing a stylesheet is reflected in the next SSR response.
- **Build/preview** — renderer route present again, `/` and `/about` 200, hashed client entry and stylesheet both injected, API routes intact.
- Plain-Vite turnkey behaviour unchanged (no ssr input configured → identical config output and middleware registration as before).

## Notes

- The trigger is a heuristic. An explicit option (`ssr: { serve: false }`, or similar) may be preferable — happy to switch if you'd rather make it declarative.
- Related to #281, but not a fix for it: that needs the `ssrLoadModule` → Environment API migration, including the server-functions middleware, which this doesn't touch. This does cover the "delegate to the provider-owned environment" case for the turnkey middleware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)