### PR TITLE
fix: prepend the server-component bootstrap to the hydration script

### DIFF
--- a/.changeset/clean-server-component-hydration.md
+++ b/.changeset/clean-server-component-hydration.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-solid': patch
+---
+
+Prevent generated server-component hydration from shifting the `<head>` structure. The bootstrap now runs at the start of the existing hydration script instead of adding an unexpected first child to `<head>`.

--- a/examples/turnkey/test/run.mjs
+++ b/examples/turnkey/test/run.mjs
@@ -1433,19 +1433,22 @@ async function runFramesChecks(mode, origin) {
     html.split(`${FRAMES_SECRET}-one`).length === 2,
   );
   record(mode, 'document', 't=0 slot records shipped (sc:slot)', html.includes('sc:slot:'));
-  // Presence is not enough: the render plugin serializes a placeholder as
-  // `self._$SC.r(id)`, so the registry must be defined BEFORE the hydration
-  // data script runs. Anchoring the injection on `</head>` put it after
-  // <HydrationScript />, and any document whose payload carried a frame ref
-  // threw "Cannot read properties of undefined (reading 'r')" — killing
-  // hydration, so nothing in the page was interactive.
+  // Presence is not enough: the bootstrap must run before hydration data,
+  // but adding a separate script before the document's declared head nodes
+  // shifts Solid's structural hydration cursor. It belongs at the front of
+  // the existing HydrationScript instead.
   const scBootstrapAt = html.indexOf('self._$SC=');
+  const hydrationRuntimeAt = html.indexOf('window._$HY');
   const hydrationDataAt = html.indexOf('_$HY.r[');
   record(
     mode,
     'document',
-    'SC bootstrap inline in head, before the hydration data script',
-    scBootstrapAt !== -1 && (hydrationDataAt === -1 || scBootstrapAt < hydrationDataAt),
+    'SC bootstrap starts the hydration script before hydration data',
+    scBootstrapAt !== -1 &&
+      hydrationRuntimeAt > scBootstrapAt &&
+      html.lastIndexOf('<script', scBootstrapAt) ===
+        html.lastIndexOf('<script', hydrationRuntimeAt) &&
+      (hydrationDataAt === -1 || scBootstrapAt < hydrationDataAt),
   );
 
   const chrome = startProcess(CHROME, [

--- a/src/ssr/index.ts
+++ b/src/ssr/index.ts
@@ -354,9 +354,9 @@ export function ssrServe(
     const composeServerFunctions = (isBuild || externalDev) && internal.serverFunctions;
     // Generated entries own the whole document wiring, so the handler also
     // injects the server-component bootstrap (the per-function-id
-    // placeholder registry the render plugin references; must be inline at
-    // the TOP of <head>, before the hydration data script streams in — see
-    // the transform below). Authored entries inject it themselves.
+    // placeholder registry the render plugin references; must start the
+    // hydration runtime script, before hydration data streams in — see the
+    // transform below). Authored entries inject it themselves.
     const injectComponentBootstrap = generated && serverComponents;
 
     const lines = [
@@ -419,17 +419,16 @@ export function ssrServe(
       // placeholder as `self._$SC.r(id)`, so a document whose payload carries
       // one throws on that reference if the registry is not defined yet.
       // <HydrationScript /> sits inside <head>, so anchoring on `</head>`
-      // always lands after it — the opening tag is the only anchor that is
-      // reliably before it.
+      // always lands after it. Prepend the bootstrap to that existing script
+      // so it runs first without adding a node that shifts hydration.
       lines.push(
         `    if (!bootstrapped) {`,
-        `      const headOpen = /<head(\\s[^>]*)?>/.exec(chunk);`,
-        `      if (headOpen) {`,
+        `      const at = chunk.indexOf('window._$HY');`,
+        `      if (at !== -1) {`,
         `        bootstrapped = true;`,
-        `        const at = headOpen.index + headOpen[0].length;`,
         `        chunk =`,
         `          chunk.slice(0, at) +`,
-        `          '<script>' + SERVER_COMPONENT_BOOTSTRAP + '</' + 'script>' +`,
+        `          SERVER_COMPONENT_BOOTSTRAP +`,
         `          chunk.slice(at);`,
         `      }`,
         `    }`,


### PR DESCRIPTION
### Problem

With `serverFunctions.components` on a generated entry, hydration reports every client component that sits in a server-component slot as unclaimed server markup:

```
Hydration completed with 9 unclaimed server-rendered node(s):
  <form _hk="sc-84ece717-0-appView-search-0" class="search" role="search">…
  <a _hk="sc-84ece717-0-appView-editButton-0" href="/new" class="edit-button…
  <div _hk="sc-a112e1b2-0-noteListView-item#0-1" class="sidebar-note-list-item…
  …
```

### Cause

`ssrServe` injects the placeholder registry as its own `<script>` immediately after the opening `<head>` tag. The ordering that anchor buys is real — the render plugin serializes placeholders as `self._$SC.r(id)`, so the registry must be defined before the hydration data script runs, and anchoring on `</head>` lands after `<HydrationScript />` — but the injected node becomes an unexpected first child of `<head>`, which Solid's structural hydration cursor walks.

### Fix

Prepend the bootstrap source to the hydration runtime script that is already in the document, instead of adding a script node. Same ordering guarantee, no extra node.

The turnkey frames check is updated to assert the new placement: the bootstrap and `window._$HY` must live in the *same* `<script>`, with the bootstrap first and still ahead of any `_$HY.r[` data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)