### PR TITLE
fix: custom `extensions` work with the native compiler

### DIFF
--- a/.changeset/native-compiler-custom-extensions.md
+++ b/.changeset/native-compiler-custom-extensions.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-solid': patch
+---
+
+Custom `extensions` work with the native compiler again. The native compiler picks its parser dialect from the file extension, so the transform builds a borrowed-extension filename (`foo.mdx` → `foo.mdx.jsx`, or `.tsx` when the extension is registered as TypeScript) for exactly this case — but only the lazy and refresh passes used it; the JSX transform itself still received the raw id, and `@dom-expressions/compiler` rejected it with "Unknown file extension" (#297). `compiler: 'babel'` was unaffected because that path names the parser plugins explicitly. The JSX transform now receives the same borrowed filename as the other native passes.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1104,7 +1104,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
 
         const result = await compiler.transformAsync(code, {
           ...solidOptions,
-          filename: id,
+          filename: nativeFilename,
           sourceMap: true,
         });
         maps.push(result.map);


### PR DESCRIPTION
Fixes #297.

## Problem

`solidPlugin({ compiler: 'native', extensions: ['.mdx'] })` fails on every custom-extension file with:

```
[solid] Unknown file extension: Please provide a valid file extension: .js, .mjs, .jsx or .cjs for JavaScript, or .ts, .d.ts, .mts, .cts or .tsx for TypeScript
```

The native compiler picks its parser dialect from the file extension, which is why the transform already builds a borrowed-extension filename for ids it doesn't recognize (`foo.mdx` → `foo.mdx.jsx`, or `.tsx` when the extension is registered with `typescript: true`). The lazy and refresh passes use it — but the native JSX transform itself still passed the raw `id`, so `@dom-expressions/compiler` rejected the file. `compiler: 'babel'` was unaffected because that path names its parser plugins explicitly, so the filename never matters.

## Fix

Pass the same borrowed `nativeFilename` to the JSX transform that the lazy and refresh passes already receive. For standard extensions `nativeFilename === id`, so nothing changes there (sourcemap `sources` included).

## Verification

Reproduced with a minimal Vite build of an `.mdx` entry containing JSX under `compiler: 'native'`, `extensions: ['.mdx']`:

- before: build fails with the "Unknown file extension" error above
- after: build succeeds and the output contains the compiled Solid template for the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)