### PR TITLE
fix(start-env): reject public-prefixed keys in the `server` schema

### DIFF
--- a/.changeset/reject-prefixed-server-env-keys.md
+++ b/.changeset/reject-prefixed-server-env-keys.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-solid': patch
+---
+
+`start.env` now rejects `server` schema keys that carry the public env prefix at config time. Vite bakes every `VITE_`-prefixed variable (or whatever `envPrefix` selects) into the browser's `import.meta.env` regardless of which side of the schema declares it, so `server: { VITE_API_SECRET: ... }` silently shipped the secret to every client through Vite's own channel — with no diagnostics, since the leak scan only watches the virtual server module's values. The prefix rule was previously enforced one-way (client keys must have it); the reverse guard now fails fast with a rename message, mirroring the existing client-side guard.

--- a/examples/start-env/env.serverprefix.ts
+++ b/examples/start-env/env.serverprefix.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+// Fixture for the config-time server-prefix guard
+// (ENV_SCHEMA=./env.serverprefix.ts): Vite bakes every VITE_-prefixed var
+// into the browser's import.meta.env regardless of schema side, so a
+// prefixed key under `server` can never stay secret and must be rejected
+// before anything builds.
+export default {
+  server: {
+    VITE_API_SECRET: z.string().min(8),
+  },
+};

--- a/examples/start-env/test/run.mjs
+++ b/examples/start-env/test/run.mjs
@@ -365,6 +365,12 @@ async function guardsMode() {
 
   out = await build({ ENV_SCHEMA: './env.badprefix.ts' }).catch((e) => e.message);
   record('guards', 'prefix', 'non-VITE_ client key is a config-time error', /must carry the public env prefix/.test(out) && /APP_NAME/.test(out), out.slice(0, 400));
+
+  // The reverse: Vite bakes every VITE_-prefixed var into the browser's
+  // import.meta.env regardless of schema side, so a prefixed SERVER key
+  // is a leak the moment it exists — reject it before anything builds.
+  out = await build({ ENV_SCHEMA: './env.serverprefix.ts' }).catch((e) => e.message);
+  record('guards', 'prefix', 'VITE_-prefixed server key is a config-time error', /cannot keep it secret/.test(out) && /VITE_API_SECRET/.test(out), out.slice(0, 400));
 }
 
 async function prodMode() {

--- a/src/start-env.ts
+++ b/src/start-env.ts
@@ -247,6 +247,27 @@ function assertSchemaShape(
       );
     }
   }
+  // The reverse guard: Vite itself bakes every prefixed variable into
+  // `import.meta.env` for the browser, so declaring one under `server`
+  // cannot keep it secret — it leaks through Vite's channel with no
+  // diagnostics from this plugin's leak scan (which only watches the
+  // virtual server module's values).
+  for (const key of Object.keys(typed.server ?? {})) {
+    const prefix = envPrefixes.find((p) => key.startsWith(p));
+    if (prefix) {
+      const bare = key.slice(prefix.length);
+      throw new Error(
+        `[vite-plugin-solid] server env var "${key}" in ${envFile} carries the public ` +
+          `env prefix "${prefix}". Vite exposes every "${prefix}"-prefixed variable to ` +
+          `the browser through import.meta.env no matter which side declares it, so a ` +
+          `\`server\` entry cannot keep it secret. ` +
+          (bare
+            ? `Rename it to "${bare}" (in the schema and in your .env/environment), or `
+            : `Rename it without the prefix, or `) +
+          `move it to \`client\` if it is public.`,
+      );
+    }
+  }
   return typed;
 }
 


### PR DESCRIPTION
## Problem

`start.env` enforces the public-prefix rule one-way only: `client` keys must carry the `VITE_` prefix (or whatever `envPrefix` selects), but `server` keys are never checked for *having* it. Vite bakes every prefixed variable into the browser's `import.meta.env` regardless of which side of the schema declares it, so this config:

```ts
export default {
  server: { VITE_API_SECRET: z.string() },
};
```

ships the secret to every client through Vite's own channel — silently. The plugin's client-chunk leak scan can't catch it because it only watches the virtual server module's values, not `import.meta.env`. In dev the full value is served to the browser; in build any client reference to `import.meta.env.VITE_API_SECRET` inlines it.

Preventing exactly this class of leak is the core promise of `start.env`, so the gap undermines the feature.

## Fix

`assertSchemaShape` now rejects `server` keys that carry any configured public prefix, failing fast at config time — mirroring the existing client-side guard — with a message explaining why (`server` cannot keep a prefixed var secret) and what to do (rename it without the prefix in the schema and the environment, or move it to `client` if it's public).

## Tests

Added `examples/start-env/env.serverprefix.ts` (fixture, following the existing `env.badprefix.ts` pattern) and a guard assertion in the start-env suite. Full suite passes locally: 45/45 assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)