### PR TITLE
fix(http): `sendWebResponse` no longer hangs when the client disconnects during backpressure

### DIFF
--- a/.changeset/send-web-response-drain-hang.md
+++ b/.changeset/send-web-response-drain-hang.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-solid': patch
+---
+
+`sendWebResponse` no longer hangs forever when a client disconnects during backpressure. The write loop's `'drain'` wait had no other way to settle, but a response whose client already went away never emits `'drain'` — so every streamed SSR response aborted mid-stream (closed tab, slow mobile client) parked the promise chain, the body reader, and the Response object permanently, accumulating leaks over a turnkey dev/preview session. The backpressure wait now also settles on `'close'`/`'error'` and the loop bails out early once the response is destroyed, letting the existing close handler's reader cancellation finish cleanup.

--- a/src/http.ts
+++ b/src/http.ts
@@ -56,8 +56,27 @@ export async function sendWebResponse(res: ServerResponse, response: Response): 
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
+      // A response whose client already went away never emits 'drain'
+      // (writes are no-ops), so a backpressure wait must also settle on
+      // 'close'/'error' or an aborted streaming response parks this promise
+      // — and the reader and Response it holds — forever.
+      if (res.destroyed) return;
       if (!res.write(value)) {
-        await new Promise((resolve) => res.once('drain', resolve));
+        const drained = await new Promise<boolean>((resolve) => {
+          const settle = (ok: boolean) => {
+            res.off('drain', onDrain);
+            res.off('close', onGone);
+            res.off('error', onGone);
+            resolve(ok);
+          };
+          const onDrain = () => settle(true);
+          const onGone = () => settle(false);
+          res.once('drain', onDrain);
+          res.once('close', onGone);
+          res.once('error', onGone);
+        });
+        // Client gone mid-stream; the 'close' handler cancels the reader.
+        if (!drained) return;
       }
     }
     res.end();


### PR DESCRIPTION
## Problem

`sendWebResponse` (the node-to-web bridge used by the turnkey dev/preview middlewares) waits out backpressure with:

```ts
if (!res.write(value)) {
  await new Promise((resolve) => res.once('drain', resolve));
}
```

A response whose client has gone away never emits `'drain'` — the disconnect surfaces as `'close'` — and the existing `'close'` handler only cancels the body reader, which unblocks a pending `read()` but not this wait. So every streamed SSR response aborted mid-stream (closed tab, slow mobile client, navigation away) parks the promise chain, the reader, and the `Response` object forever. Over a dev/preview session these leaks accumulate with no visible cause.

## Fix

The backpressure wait now settles on `'drain'`, `'close'`, or `'error'` (listeners removed either way), and the write loop bails out early when the response is already destroyed. On disconnect the function returns and the existing `'close'` handler's reader cancellation completes cleanup; the success path is unchanged.

## Verification

Two scripts driving a real `node:http` server through `sendWebResponse`:

- **Abort repro** — client connects, never reads (TCP backpressure makes `res.write` return `false`), then destroys the socket while the server awaits drain. Before: the `sendWebResponse` promise never settles. After: it settles promptly.
- **Happy path** — a slow consumer reads a 4 MB stream to completion through repeated drain cycles: all bytes delivered, promise resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)