### PR TITLE
fix: update HMR condition to exclude test mode

### DIFF
--- a/.changeset/gentle-melons-jump.md
+++ b/.changeset/gentle-melons-jump.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-solid": patch
+---
+
+fix: exclude test mode from HMR setup

--- a/src/index.ts
+++ b/src/index.ts
@@ -329,7 +329,11 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
     },
 
     configResolved(config) {
-      needHmr = config.command === 'serve' && config.mode !== 'production' && options.hot !== false;
+      needHmr =
+        !isTestMode &&
+        config.command === 'serve' &&
+        config.mode !== 'production' &&
+        options.hot !== false;
     },
 
     resolveId(id) {


### PR DESCRIPTION
Disable HMR injection in test mode. 

This plugin previously injected `solid-refresh` HMR code into every transformed module when running vitest. The injected `if (import.meta.hot)` branch does not exist in the source, which made coverage reports (e.g. `vitest run --coverage`) show branches/lines that do not match the source. 

Although we can pass `{ hot: false }` to escape the situation, it's better to bypass all test scenarios by default.

Test mode now skips HMR injection so coverage mappings align with the source.