### PR TITLE
fix(start): apply nonce to generated client entry

### DIFF
--- a/.changeset/client-entry-csp-nonce.md
+++ b/.changeset/client-entry-csp-nonce.md
@@ -1,0 +1,5 @@
+---
+'@solidjs/vite-plugin': patch
+---
+
+Apply the request CSP nonce to start mode's generated client-entry script.

--- a/examples/turnkey/test/run.mjs
+++ b/examples/turnkey/test/run.mjs
@@ -951,6 +951,16 @@ async function runProdMode() {
       fetchableHtml.includes('SSR Start Mode') &&
       !fetchableHtml.includes('provider-argument-must-not-be-forwarded'),
   );
+  const nonceResponse = await builtHandler.handleRequest(new Request(origin + '/'), {
+    nonce: 'test"<&',
+  });
+  const nonceHtml = await nonceResponse.text();
+  record(
+    mode,
+    'build',
+    'client entry carries the escaped CSP nonce',
+    nonceHtml.includes('<script type="module" nonce="test&quot;&lt;&amp;" src="'),
+  );
   record(
     mode,
     'build',

--- a/src/ssr/index.ts
+++ b/src/ssr/index.ts
@@ -721,7 +721,12 @@ export function startServe(
     // every positional claim after it.
     lines.push(
       ``,
-      `function createHtmlChunkTransform(clientEntry, extraHead) {`,
+      `function escapeAttribute(value) {`,
+      `  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');`,
+      `}`,
+      ``,
+      `function createHtmlChunkTransform(clientEntry, extraHead, nonce) {`,
+      `  const nonceAttr = nonce ? ' nonce="' + escapeAttribute(nonce) + '"' : '';`,
       `  let first = true;`,
       `  let injected = false;`,
       `  return (chunk) => {`,
@@ -767,7 +772,7 @@ export function startServe(
       // fresh render-into-body mount (hydration, by contrast, wants to
       // start as early as possible).
       headParts.push(
-        `(clientEntry ? '<script type="module" src="' + clientEntry + '"${clientMode ? '' : ' async'}></' + 'script>' : '')`,
+        `(clientEntry ? '<script type="module"' + nonceAttr + ' src="' + clientEntry + '"${clientMode ? '' : ' async'}></' + 'script>' : '')`,
       );
     }
     if (headParts.length) {
@@ -851,7 +856,7 @@ export function startServe(
       `  return createSSRResponse(result, event, {`,
       `    responseInit: options.responseInit,`,
       `    nonce: options.nonce,`,
-      `    transformChunk: createHtmlChunkTransform(clientEntry, options.devHead),`,
+      `    transformChunk: createHtmlChunkTransform(clientEntry, options.devHead, options.nonce),`,
       `  });`,
       `}`,
       ``,


### PR DESCRIPTION
## Summary

- pass `options.nonce` into the HTML head transform
- apply an escaped nonce to the generated client-entry script
- cover nonce propagation and attribute escaping in the production fixture
- add a patch changeset

Ports the SPA entry portion of [solidjs/solid-start@d8f1ea8](https://github.com/solidjs/solid-start/commit/d8f1ea85bf8114713d60deeae24389d5dfe6732f) ([solid-start#2252](https://github.com/solidjs/solid-start/pull/2252)). The streaming-redirect portion is already handled by `@solidjs/web`.

## Testing

- `pnpm build`
- `pnpm check`
- `node test/run.mjs prod` (52/52 assertions)
