### PR TITLE
test: cover server-function CSRF integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,6 +654,19 @@ production handler alike), and edits to the module hot-invalidate the
 handler in dev. Config calls merge per key, so it composes with the
 plugin's own runtime configuration.
 
+Server-function requests are same-origin protected by `@solidjs/web`. To
+allow another trusted origin, configure it in the same server-only module:
+
+```ts
+import { configureServerFunctionsServer } from '@solidjs/web/server-functions/server';
+
+configureServerFunctionsServer({
+  csrf: { origin: ['https://app.example.com'] },
+});
+```
+
+Set `csrf: false` only when another trusted layer protects the endpoint.
+
 Meta-frameworks that need to control plugin ordering and dispatch requests
 through their own server should use the standalone `serverFunctions()`
 export instead, which never installs the dev middleware. See

--- a/examples/start-ssr/test/run.mjs
+++ b/examples/start-ssr/test/run.mjs
@@ -129,6 +129,15 @@ import {
   resolveConfig,
 } from 'vite';
 
+const nativeFetch = globalThis.fetch;
+function fetch(input, init) {
+  const request = new Request(input, init);
+  if (!request.headers.has('Sec-Fetch-Site')) {
+    request.headers.set('Sec-Fetch-Site', 'same-origin');
+  }
+  return nativeFetch(request);
+}
+
 const exampleDir = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 // Deliberately no process.chdir(exampleDir): the in-process modes (external,
 // detect) create the dev server with `root: exampleDir` while the runner's
@@ -295,6 +304,22 @@ function extractFunctionId(transformedCode, name) {
   // newer compilers pass the function name as a second argument after the id.
   const match = transformedCode.match(new RegExp(`createServerReference\\w*\\("([^"]*-${name})"`));
   return match ? match[1] : null;
+}
+
+async function runCsrfChecks(mode, origin) {
+  const crossSite = await fetch(origin + '/_server?id=csrf-probe', {
+    method: 'POST',
+    headers: { 'Sec-Fetch-Site': 'cross-site' },
+  });
+  record(
+    mode,
+    'csrf',
+    'cross-site server function request rejected',
+    crossSite.status === 403,
+  );
+
+  const sameOrigin = await fetch(origin + '/_server?id=csrf-probe', { method: 'POST' });
+  record(mode, 'csrf', 'same-origin request reaches dispatch', sameOrigin.status === 404);
 }
 
 // Distinctive rule from src/App.css: proves real styles (not just the dev
@@ -899,6 +924,7 @@ async function runDevMode() {
     );
     const bogus = await fetch(origin + '/_server?id=bogus-0');
     record(mode, 'sf', 'dev middleware rejects unknown id', bogus.status === 404);
+    await runCsrfChecks(mode, origin);
 
     const html = await runSsrChecks(mode, origin);
     record(mode, 'dev', 'Vite client injected into <head>', html.includes('/@vite/client'));
@@ -1166,6 +1192,7 @@ async function runProdMode() {
 
     const bogus = await fetch(origin + '/_server?id=bogus-0');
     record(mode, 'sf', 'prod handler rejects unknown id', bogus.status === 404);
+    await runCsrfChecks(mode, origin);
 
     const html = await runSsrChecks(mode, origin);
     record(


### PR DESCRIPTION
## Summary

- document Solid Web’s default same-origin protection for server functions
- make the Start SSR Node harness send browser-style Sec-Fetch-Site metadata
- verify cross-site rejection and same-origin dispatch in development and production

## Prerequisite

Depends on [solid#3027](https://github.com/solidjs/solid/pull/3027), which adopts the runtime protection from [dom-expressions#571](https://github.com/ryansolid/dom-expressions/pull/571).

This stays draft until the corresponding @solidjs/web release is available. There is no plugin changeset because the policy and runtime behavior live in Solid Web. This PR documents and verifies the existing Vite integration.

## Testing

Tested against a simulated @solidjs/web@2.0.0-rc.2 built from solid#3027:

- pnpm build
- Start SSR development mode: 65/65 assertions
- Start SSR production mode: 58/58 assertions