### PR TITLE
Avoid overriding environments configured in Vitest workspaces

### DIFF
--- a/.changeset/fix-vitest-workspace-environment.md
+++ b/.changeset/fix-vitest-workspace-environment.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-solid': patch
+---
+
+Avoid overriding environments configured in Vitest workspaces and projects with the `jsdom` default

--- a/src/index.ts
+++ b/src/index.ts
@@ -238,7 +238,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
             ? [userTest.setupFiles]
             : userTest.setupFiles || [];
 
-        if (!userTest.environment && !options.ssr) {
+        if (!userTest.environment && !userTest.workspace && !userTest.projects && !options.ssr) {
           test.environment = 'jsdom';
         }
 


### PR DESCRIPTION
Fixes #205.

The Solid Vite plugin was injecting `jsdom` whenever the top-level Vitest config did not define `test.environment`. This overrode environments configured inside Vitest workspaces.

The plugin now skips the `jsdom` default when `test.workspace` or `test.projects` is configured, allowing each workspace/project to control its own environment.