### PR TITLE
fix: do not enable devtools from Vite's optional-peer-dep stub

### DIFF
--- a/.changeset/devtools-optional-peer-stub.md
+++ b/.changeset/devtools-optional-peer-stub.md
@@ -1,0 +1,5 @@
+---
+'@solidjs/vite-plugin': patch
+---
+
+Start devtools are no longer enabled when `@solidjs/start-devtools` is not installed. Detection falls back to resolving the package from the plugin's own file (for pnpm-isolated installs where it is only a dependency of the plugin), but the package is declared an optional peer dependency of the plugin, so when it is absent Vite answers that resolution with its `__vite-optional-peer-dep:` stub instead of `null`. The plugin took the stub as a successful resolution, wrapped the generated client entry in `DevToolbar`, and the browser failed with `The requested module '/@id/__vite-optional-peer-dep:@solidjs/start-devtools:@solidjs/vite-plugin' does not provide an export named 'DevToolbar'`. The stub is now treated as "not installed".

--- a/src/ssr/index.ts
+++ b/src/ssr/index.ts
@@ -489,11 +489,18 @@ export function startServe(
     // from the plugin's own file: in pnpm-isolated apps a copy that is only a
     // dependency of the plugin is not reachable from the app's importers. The
     // resolved id is kept so imports from generated modules can use it.
-    devtoolsResolutions[consumer] ??= (async () =>
-      (
-        (await resolve(DEVTOOLS_PACKAGE, importer)) ??
-        (await resolve(DEVTOOLS_PACKAGE, fileURLToPath(import.meta.url)))
-      )?.id ?? null)();
+    devtoolsResolutions[consumer] ??= (async () => {
+      // Resolving from the plugin's own file never yields null when the
+      // package is absent: it is declared an optional peer dependency, so
+      // Vite answers with its `__vite-optional-peer-dep:` stub (an empty
+      // module). Treat that stub as "not installed".
+      const realId = (resolved: { id: string } | null) =>
+        resolved && !resolved.id.startsWith('__vite-optional-peer-dep:') ? resolved.id : null;
+      return (
+        realId(await resolve(DEVTOOLS_PACKAGE, importer)) ??
+        realId(await resolve(DEVTOOLS_PACKAGE, fileURLToPath(import.meta.url)))
+      );
+    })();
     const id = await devtoolsResolutions[consumer];
     devtoolsIds[consumer] = id;
     if (!id && options.devtools === true) {


### PR DESCRIPTION
## Problem

Any Start app that does **not** install `@solidjs/start-devtools` fails in dev on `3.0.0-next.31`:

```
Uncaught SyntaxError: The requested module '/@id/__vite-optional-peer-dep:@solidjs/start-devtools:@solidjs/vite-plugin' does not provide an export named 'DevToolbar'
```

`resolveDevtools` falls back to resolving the package from the plugin's own file (for pnpm-isolated installs where devtools is only a dependency of the plugin). But `@solidjs/start-devtools` is declared an *optional peer dependency* of the plugin, so when it is absent Vite does not return `null` for that resolution — it returns its `__vite-optional-peer-dep:` stub (an empty module). The plugin took the stub as a real resolution, enabled the toolbar, and the generated client entry imported `DevToolbar` from an empty module.

## Fix

Treat an id starting with `__vite-optional-peer-dep:` as "not installed" in both resolution attempts.

## Verification

- Reproduced with the bare template + next.31 and no devtools installed; with the patched build the generated entry no longer imports devtools and the app boots with no console errors.
- `examples/start-client/test/run.mjs`: 45/45 (toolbar still wraps the app when devtools *is* installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)