### PR TITLE
fix: don't crash the boundary guard when environment is missing

### DIFF
--- a/.changeset/boundary-modules-environment-consumer.md
+++ b/.changeset/boundary-modules-environment-consumer.md
@@ -1,0 +1,9 @@
+---
+'@solidjs/vite-plugin': patch
+---
+
+The `server-only`/`client-only` boundary guard no longer crashes when
+`this.environment` isn't available on resolve hooks, and now detects the
+target environment through the same `getEnvironmentConsumer` helper used
+by the rest of the plugin, falling back to the resolve hook's `ssr` flag
+when the environment is absent.

--- a/src/boundary-modules.ts
+++ b/src/boundary-modules.ts
@@ -1,4 +1,5 @@
 import type { Plugin } from 'vite';
+import { getEnvironmentConsumer } from './environment';
 
 const VIRTUAL_ID = '\0@solidjs/vite-plugin:boundary-modules';
 
@@ -34,7 +35,7 @@ export function boundaryModules(): Plugin {
       // scan all the same. Real dev/build module graphs resolve without
       // the flag and stay fully guarded.
       const scan = !!(options as { scan?: boolean } | undefined)?.scan;
-      const server = this.environment.config.consumer === 'server';
+      const server = getEnvironmentConsumer(this.environment, options) === 'server';
       if (id === 'server-only') {
         if (!server && !scan)
           this.error(


### PR DESCRIPTION
### Background
I got
```bash
TypeError: Cannot read properties of undefined (reading 'config')
``` 
on Solid 2 migration bundling with tsdown.

### Solution
The `server-only`/`client-only` boundary guard no longer crashes when `this.environment` isn't available on resolve hooks, and now detects the target environment through the same `getEnvironmentConsumer` helper used by the rest of the plugin, falling back to the resolve hook's `ssr` flag when the environment is absent.