### PR TITLE
Announce diagnostics endpoint and agent skills in dev-server startup output

### DIFF
--- a/.changeset/diagnostics-startup-banner.md
+++ b/.changeset/diagnostics-startup-banner.md
@@ -1,0 +1,5 @@
+---
+'@solidjs/vite-plugin': patch
+---
+
+Announce the diagnostics surface in the dev-server startup block when `diagnostics: true` is set: two extra lines after Vite's URLs naming the `/__solid/diagnostics` endpoint (with its method vocabulary) and the agent skill documents shipped in node_modules. Startup output is the one channel agents reliably read even in projects with no AGENTS.md, making this the discovery path for existing apps and ports. Dev-serve only.

--- a/src/diagnostics/index.ts
+++ b/src/diagnostics/index.ts
@@ -159,6 +159,24 @@ export function solidDiagnostics(): Plugin {
     },
 
     configureServer(server) {
+      // Announce the surface in the startup block. This is a discovery
+      // channel: agents watching dev-server output learn the endpoint and
+      // the skill documents without any project-level pointer (AGENTS.md).
+      const originalPrintUrls = server.printUrls.bind(server);
+      server.printUrls = () => {
+        originalPrintUrls();
+        const local = server.resolvedUrls?.local[0];
+        const endpoint = local
+          ? new URL(DIAGNOSTICS_ENDPOINT, local).href
+          : DIAGNOSTICS_ENDPOINT;
+        server.config.logger.info(
+          `  ➜  Solid diagnostics: ${endpoint} ` +
+            `(GET status; POST {"method":"begin"|"end"|"whyDidRun"|"costs"})\n` +
+            `  ➜  Agent skills: node_modules/${DIAGNOSTICS_PACKAGE}/skills/agent-loops/SKILL.md, ` +
+            `node_modules/solid-js/skills/reactivity-diagnostics/SKILL.md`,
+        );
+      };
+
       interface Pending {
         resolve: (response: DiagnosticsResponse) => void;
         timer: ReturnType<typeof setTimeout>;


### PR DESCRIPTION
## Summary
- With `diagnostics: true`, the dev server startup block gains two lines after Vite's URLs: the `/__solid/diagnostics` endpoint (with its POST method vocabulary) and the paths of the agent skill documents shipped in `node_modules` (`@solidjs/diagnostics` agent loops, `solid-js` reactivity repair guide).
- Startup output is the one channel agents reliably read even in projects with no `AGENTS.md` — this is the discovery path for existing apps and ports, complementing the scaffold-level pointers added to the solid-v2 templates (solidjs/templates#283).
- Dev-serve only; no output change for builds, preview, or when the option is off.

Verified live against a scaffolded app:

```
  ➜  Local:   http://localhost:3011/
  ➜  Network: use --host to expose
  ➜  Solid diagnostics: http://localhost:3011/__solid/diagnostics (GET status; POST {"method":"begin"|"end"|"whyDidRun"|"costs"})
  ➜  Agent skills: node_modules/@solidjs/diagnostics/skills/agent-loops/SKILL.md, node_modules/solid-js/skills/reactivity-diagnostics/SKILL.md
```

Made with [Cursor](https://cursor.com)