### PR TITLE
Add experimental TSRX support

### DIFF
--- a/.changeset/support-tsrx-vite.md
+++ b/.changeset/support-tsrx-vite.md
@@ -1,0 +1,5 @@
+---
+'@solidjs/vite-plugin': patch
+---
+
+Add experimental `.tsrx` compilation with native and Babel backends, scoped CSS sidecars, HMR and SSR asset integration, and function-level server functions.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Join [solid discord](https://discord.com/invite/solidjs) and check the [troubles
 - Drop-in installation as a vite plugin
 - Minimal bundle size
 - Support typescript (`.tsx`) out of the box
+- Experimental TypeScript TSRX (`.tsrx`) support out of the box
 - Support code splitting out of the box
 
 ## Requirements
@@ -499,8 +500,8 @@ assets.
 **Entry resolution** (all paths relative to the Vite root):
 
 1. Explicit `start.entryServer` / `start.entryClient` options.
-2. Conventional files: `src/entry-server.{tsx,jsx,ts,js,mjs}` and
-   `src/entry-client.{tsx,jsx,ts,js,mjs}`. Entry files come in pairs —
+2. Conventional files: `src/entry-server.{tsx,jsx,ts,js,mjs,tsrx}` and
+   `src/entry-client.{tsx,jsx,ts,js,mjs,tsrx}`. Entry files come in pairs —
    providing only one is an error. The server entry must export
    `render(request?, context?)` returning a `renderToStream` result, an HTML
    string, or a `Response`; `context.clientEntry` carries the resolved
@@ -509,8 +510,8 @@ assets.
    the hashed asset (the classic harness convention keeps working).
 3. Generated entries (the zero-config path): when no entry files exist, both
    are generated from a root component — `start.app`, defaulting to
-   `src/App.{tsx,jsx,ts,js}` (or lowercase `src/app.*`) — wrapped in a
-   document shell: `start.document`, defaulting to `src/Document.{tsx,jsx}`,
+   `src/App.{tsx,jsx,ts,js,tsrx}` (or lowercase `src/app.*`) — wrapped in a
+   document shell: `start.document`, defaulting to `src/Document.{tsx,jsx,tsrx}`,
    else a built-in minimal shell. A custom document receives the app as
    `props.children` and must render the full `<html>` document including
    `<HydrationScript />`; the client entry script is injected into `<head>`
@@ -714,12 +715,40 @@ export default defineConfig({
 });
 ```
 
+#### Experimental TSRX
+
+Files ending in `.tsrx` are recognized automatically as TypeScript TSRX; they
+do not need to be listed in `options.extensions`. Both the native and Babel
+compiler backends preserve the `.tsrx` filename when invoking their TSRX
+frontends.
+
+Scoped CSS emitted by either backend is exposed as a sibling virtual CSS
+sidecar and imported once from the compiled module. The sidecar goes through
+Vite's normal CSS pipeline, so extraction and injection work in development,
+production builds, and SSR, including client HMR and SSR development style
+collection. A file that emits no CSS has no sidecar import.
+
+The Babel backend chains TSRX source maps through the later lazy-module and
+refresh transforms. The native compiler does not currently emit the required
+TSRX projection map, so native `.tsrx` transforms return no source map. With
+`compiler: "native"` and custom `babel` options, the custom Babel support pass
+runs after native TSRX lowering (on ordinary JavaScript); ordinary JSX/TSX
+keeps the existing pre-native ordering.
+
+With `serverFunctions` enabled, function-level `"use server"` directives work
+in `.tsrx` with both compiler backends. The plugin lowers TSRX first, then runs
+the same native directive transform while retaining the authored `.tsrx` path
+for stable client/server function IDs. TSRX's host-defined
+`module server { ... }` profile is not supported.
+
 #### options.babel
 
 - Type: Babel.TransformOptions
 - Default: {}
 
 Pass any additional [babel transform options](https://babeljs.io/docs/en/options). Those will be merged with the transformations required by Solid.
+With the native compiler these options normally run before JSX lowering; for
+`.tsrx` only, they run after native TSRX lowering as described above.
 
 #### options.solid
 
@@ -744,7 +773,8 @@ Pass any additional [@babel/preset-typescript](https://babeljs.io/docs/en/babel-
 - Default: []
 
 An array of custom extension that will be passed through the solid compiler.
-By default, the plugin only transform `jsx` and `tsx` files.
+By default, the plugin transforms `jsx`, `tsx`, and experimental `tsrx` files.
+TSRX is always recognized and does not need to be added here.
 This is useful if you want to transform `mdx` files for example.
 
 ## `server-only` and `client-only` boundary markers

--- a/examples/vite-8/package.json
+++ b/examples/vite-8/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "@solidjs/testing-library": "^1.0.0-beta.2",
+    "@tsrx/core": "0.1.63",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/user-event": "^14.6.1",
     "@vitest/browser": "^4.1.11",

--- a/examples/vite-8/src/App.tsx
+++ b/examples/vite-8/src/App.tsx
@@ -1,6 +1,7 @@
 import { onSettled } from "solid-js";
 import { CounterProvider, useCounter } from "./CounterContext";
 import { title } from './UnusedLazyImporter';
+import { TsrxCard } from './TsrxCard.tsrx';
 
 function Count() {
   const counter = useCounter();
@@ -50,6 +51,7 @@ export default function App() {
       <Count />
       <Increment />
       <Decrement />
+      <TsrxCard label="TSRX scoped styles" />
     </CounterProvider>
   );
 }

--- a/examples/vite-8/src/TsrxCard.tsrx
+++ b/examples/vite-8/src/TsrxCard.tsrx
@@ -1,0 +1,21 @@
+export async function saveCard() {
+  "use server";
+  return "saved";
+}
+
+export function TsrxCard(props: { label: string }) @{
+  <>
+    <style>
+      .card {
+        color: rgb(12, 34, 56);
+      }
+
+      .unused {
+        color: red;
+      }
+    </style>
+    <section data-testid="tsrx-card" data-server-function={typeof saveCard} class="card">
+      {props.label}
+    </section>
+  </>
+}

--- a/examples/vite-8/tests/App.test.tsx
+++ b/examples/vite-8/tests/App.test.tsx
@@ -18,4 +18,9 @@ test('App', async () => {
   const decrementButton = root.getByText('Decrement');
   await decrementButton.click();
   await expect.element(count).toHaveTextContent('Counter: 0');
+
+  const tsrxCard = root.getByTestId('tsrx-card');
+  await expect.element(tsrxCard).toHaveTextContent('TSRX scoped styles');
+  await expect.element(tsrxCard).toHaveAttribute('data-server-function', 'function');
+  await expect.element(tsrxCard).toHaveStyle({ color: 'rgb(12, 34, 56)' });
 });

--- a/examples/vite-8/vite.config.ts
+++ b/examples/vite-8/vite.config.ts
@@ -19,8 +19,11 @@ export default defineConfig({
         }
       },
     },
-    // Rides the native compiler default.
-    solidPlugin({ ssr: true }),
+    solidPlugin({
+      ssr: true,
+      serverFunctions: true,
+      compiler: process.env.SOLID_COMPILER === 'babel' ? 'babel' : 'native',
+    }),
     {
       name: 'assert-single-entry',
       enforce: 'post',

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
   "dependencies": {
     "@ampproject/remapping": "^2.3.0",
     "@babel/core": "^7.23.3",
-    "@solidjs/babel-plugin": "^2.0.0-rc.3",
-    "@solidjs/compiler": "^2.0.0-rc.3",
+    "@solidjs/babel-plugin": "^2.0.0-rc.6",
+    "@solidjs/compiler": "^2.0.0-rc.6",
     "@types/babel__core": "^7.20.4",
     "merge-anything": "^5.1.7",
     "vitefu": "^1.0.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   default:
     '@solidjs/web':
-      specifier: ^2.0.0-rc.5
-      version: 2.0.0-rc.5
+      specifier: ^2.0.0-rc.6
+      version: 2.0.0-rc.6
     solid-js:
-      specifier: ^2.0.0-rc.5
-      version: 2.0.0-rc.5
+      specifier: ^2.0.0-rc.6
+      version: 2.0.0-rc.6
 
 importers:
 
@@ -24,14 +24,14 @@ importers:
         specifier: ^7.23.3
         version: 7.29.7
       '@solidjs/babel-plugin':
-        specifier: ^2.0.0-rc.3
-        version: 2.0.0-rc.5(@babel/core@7.29.7)
+        specifier: ^2.0.0-rc.6
+        version: 2.0.0-rc.6(@babel/core@7.29.7)(@tsrx/core@0.1.63)
       '@solidjs/compiler':
-        specifier: ^2.0.0-rc.3
-        version: 2.0.0-rc.5
+        specifier: ^2.0.0-rc.6
+        version: 2.0.0-rc.6
       '@solidjs/web':
         specifier: ^2.0.0-rc.0
-        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
+        version: 2.0.0-rc.6(solid-js@2.0.0-rc.6)
       '@testing-library/jest-dom':
         specifier: ^5.16.6 || ^5.17.0 || ^6.*
         version: 6.10.0(@testing-library/dom@10.4.1)
@@ -68,10 +68,10 @@ importers:
         version: 0.2.2
       '@solidjs/diagnostics':
         specifier: ^2.0.0-rc.3
-        version: 2.0.0-rc.5(vitest@4.1.11)
+        version: 2.0.0-rc.6(vitest@4.1.11)
       '@solidjs/start-devtools':
         specifier: ^1.0.0-next.3
-        version: 1.0.0-next.4(@solidjs/web@2.0.0-rc.5(solid-js@2.0.0-rc.5))(solid-js@2.0.0-rc.5)
+        version: 1.0.0-next.4(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.3
@@ -98,7 +98,7 @@ importers:
         version: 1.0.0(rollup@4.62.2)
       solid-js:
         specifier: ^2.0.0-rc.0
-        version: 2.0.0-rc.5
+        version: 2.0.0-rc.6
       typescript:
         specifier: ^5.2.2
         version: 5.9.3
@@ -110,10 +110,10 @@ importers:
     dependencies:
       '@solidjs/web':
         specifier: 'catalog:'
-        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
+        version: 2.0.0-rc.6(solid-js@2.0.0-rc.6)
       solid-js:
         specifier: 'catalog:'
-        version: 2.0.0-rc.5
+        version: 2.0.0-rc.6
     devDependencies:
       '@solidjs/vite-plugin':
         specifier: workspace:*
@@ -126,10 +126,10 @@ importers:
     dependencies:
       '@solidjs/web':
         specifier: 'catalog:'
-        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
+        version: 2.0.0-rc.6(solid-js@2.0.0-rc.6)
       solid-js:
         specifier: 'catalog:'
-        version: 2.0.0-rc.5
+        version: 2.0.0-rc.6
     devDependencies:
       '@solidjs/vite-plugin':
         specifier: workspace:*
@@ -142,10 +142,10 @@ importers:
     dependencies:
       '@solidjs/web':
         specifier: 'catalog:'
-        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
+        version: 2.0.0-rc.6(solid-js@2.0.0-rc.6)
       solid-js:
         specifier: 'catalog:'
-        version: 2.0.0-rc.5
+        version: 2.0.0-rc.6
     devDependencies:
       '@solidjs/vite-plugin':
         specifier: workspace:*
@@ -158,10 +158,10 @@ importers:
     dependencies:
       '@solidjs/web':
         specifier: 'catalog:'
-        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
+        version: 2.0.0-rc.6(solid-js@2.0.0-rc.6)
       solid-js:
         specifier: 'catalog:'
-        version: 2.0.0-rc.5
+        version: 2.0.0-rc.6
       valibot:
         specifier: ^1.1.0
         version: 1.4.2(typescript@5.9.3)
@@ -183,10 +183,10 @@ importers:
     dependencies:
       '@solidjs/web':
         specifier: 'catalog:'
-        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
+        version: 2.0.0-rc.6(solid-js@2.0.0-rc.6)
       solid-js:
         specifier: 'catalog:'
-        version: 2.0.0-rc.5
+        version: 2.0.0-rc.6
     devDependencies:
       '@solidjs/vite-plugin':
         specifier: workspace:*
@@ -205,14 +205,14 @@ importers:
     dependencies:
       '@solidjs/web':
         specifier: 'catalog:'
-        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
+        version: 2.0.0-rc.6(solid-js@2.0.0-rc.6)
       solid-js:
         specifier: 'catalog:'
-        version: 2.0.0-rc.5
+        version: 2.0.0-rc.6
     devDependencies:
       '@solidjs/testing-library':
         specifier: ^1.0.0-beta.2
-        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.5(solid-js@2.0.0-rc.5))(solid-js@2.0.0-rc.5)
+        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)
       '@solidjs/vite-plugin':
         specifier: workspace:*
         version: link:../..
@@ -222,6 +222,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@tsrx/core':
+        specifier: 0.1.63
+        version: 0.1.63
       '@vitest/browser':
         specifier: ^4.1.11
         version: 4.1.11(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2))(vitest@4.1.11)
@@ -1075,6 +1078,10 @@ packages:
       '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.4
       '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.4
 
+  '@noble/hashes@2.4.0':
+    resolution: {integrity: sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==}
+    engines: {node: '>= 20.19.0'}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1355,53 +1362,57 @@ packages:
     resolution: {integrity: sha512-T4Wyi9lUuz0a1C2OHuzqZ0aFOCI0AmaGTb2LP9sHgWdoHXlB3JU02gfBpa0Y081G/gFsJYpQ/R0iCJRzF/nknw==}
     hasBin: true
 
-  '@solidjs/babel-plugin@2.0.0-rc.5':
-    resolution: {integrity: sha512-Wd2cHNSRBxisVXTsl0Nq+21+0DFVYeKLQxnZqQqxCqXM8cEnijv6tfcIUzlSEp3esEyQD0gXnbQpSOyoLkHCwg==}
+  '@solidjs/babel-plugin@2.0.0-rc.6':
+    resolution: {integrity: sha512-bPw4UjS4OGgIHxetWwEj1OEBpU59RYt7t2jE1QPxqYlomJiS2fQFLiXFy62rkqme+zAFVWNV4SMyS+2THQI2Mw==}
     peerDependencies:
       '@babel/core': ^7.20.12
+      '@tsrx/core': 0.1.63
+    peerDependenciesMeta:
+      '@tsrx/core':
+        optional: true
 
-  '@solidjs/compiler-darwin-arm64@2.0.0-rc.5':
-    resolution: {integrity: sha512-rCSbArP+hLkYeUPdw6OisdQD313VxP+oaI7FOLohSx1FfiEOVwyAvKgYqGROe4T0ZZXjgTkSZUKHBzbG468j4A==}
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.6':
+    resolution: {integrity: sha512-uTZeFIIqsoDEgp4YUDrmnrIt63Hgz5quEIDexTnzcL6sPUpSMFoDGtNR5db6+d/pCUXAAE8ZgimpG0EJ6gOOiw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@solidjs/compiler-darwin-x64@2.0.0-rc.5':
-    resolution: {integrity: sha512-l1P0zal1yKy2k/TNMqnh2jFf7CkCr2Iu/AM45Rai65NW2n7zgPO+2LY6kDKCO/ooU4ZZ3FdnTKpwza6mT1xqUQ==}
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.6':
+    resolution: {integrity: sha512-GmUujhjlOT9TBm10+8qS8Ft0sKc5that4CFmj4klbt40PywwPDfdhEzlw+awhlFgl+7FN75q+tRQdQJFNcrAgA==}
     cpu: [x64]
     os: [darwin]
 
-  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.5':
-    resolution: {integrity: sha512-G2BBNzwIUJHtAxPISMjtMi+IsgyCWfJ29tS4MxfUC+Q4aEykTV55ybItAAffwF9YgeHA6JtQY3iVU002QGJDuw==}
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.6':
+    resolution: {integrity: sha512-/edSzc/fjl+QCYeaAxSEQwpOBiaB5DNrb8EUm4zKQHGWY1WwFeKSkSLoMKwnhmwCu+SIt1Z8fTEG6lZirUj1hw==}
     cpu: [arm64]
     os: [linux]
 
-  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.5':
-    resolution: {integrity: sha512-3ckN7cot0FiUiGUSnnKJON+sOJgIS8zuEXUPUv/ijjE+gA9pEepX8u06/DXzvEXkrDzPHGWrFx+v19Aogl+l5g==}
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.6':
+    resolution: {integrity: sha512-EWb0ypXtL7LbLn70M7O6FmK3pOKNDX9HaQETCiwZxjj/AXP7zYDsb7H5M1HsprbeXspij5+gft9Oeq7NfJJ+mQ==}
     cpu: [x64]
     os: [linux]
 
-  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.5':
-    resolution: {integrity: sha512-1l35k2lCYtpIV/RZBqpy9y7JNMruGAlMBZVxjIHDxCJDs9vKLue/7WPT0qg7cm3dCqa69hVxRNBQYqRHLa4P2g==}
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.6':
+    resolution: {integrity: sha512-aQCYH+d3TAx1i05vtdINSRnKxPFL8VnkSOoab2OkX3rmxwCGxpRRUvj+fOePiF28XO4ijDoY7Bty4QsP1jbUUw==}
     engines: {node: '>=14.0.0'}
 
-  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.5':
-    resolution: {integrity: sha512-ZYumQABKyBWv0iEonwcMnrjOt1cKWdjdBeKc9xQ0eNxqMlJsOQvRFMB3Ow7OS2U2aYKfAIzfcPCKgsXv9JbIvA==}
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.6':
+    resolution: {integrity: sha512-8luAnqBxHJxEfw8SKqKGV1W2x+j1yk0G2rb242/z45pbVkQz+J5HNKMYSnvfKN3B2VpIvhZ447yph449wDKpEA==}
     cpu: [x64]
     os: [win32]
 
-  '@solidjs/compiler@2.0.0-rc.5':
-    resolution: {integrity: sha512-DQF24zYiTW4GDhhOTITEjjK1PGvPGx8P3qR6ogWBeaXggeMN6vV2s0oqyrYoJr2g2ufJj1vf2FIdLVDu8Ip7zw==}
+  '@solidjs/compiler@2.0.0-rc.6':
+    resolution: {integrity: sha512-3B6zdACJp+lImXJW/E0E5cXfsMlMXSIg9+s8me2sxz5Q4juGptiW+aUtluDb2e+lCUZt7kDVZdy5eHOmZ3T/mA==}
 
-  '@solidjs/diagnostics@2.0.0-rc.5':
-    resolution: {integrity: sha512-qHOuFoGpyiPgSXP3VktxX7SshVQ3k04y5c3SJEcK2uWRY50Zzdq46iWEmej3ohhY7EFK+lQ1BS7i3rttC9pY7w==}
+  '@solidjs/diagnostics@2.0.0-rc.6':
+    resolution: {integrity: sha512-Q+4x6iwJCW+mV2jVMboaKubdjEUruirbgp+I4sa0XfNZFrbL1EQluiNqVpYL4Q0HszTzboRh2a2Rzob7OG7DTw==}
     peerDependencies:
       vitest: '>=2.0.0'
     peerDependenciesMeta:
       vitest:
         optional: true
 
-  '@solidjs/signals@2.0.0-rc.5':
-    resolution: {integrity: sha512-Ks+97LbyN2vYqPEHWpy2YY+MYgoSCge0kHOUFN/Bzdz1Ex/M9Is1HIyBZGBVhf5y35394List5WWlU44yEnm4w==}
+  '@solidjs/signals@2.0.0-rc.6':
+    resolution: {integrity: sha512-lPqwZNLPq1Z9CBvgXkMvi1ZFr5OHUiFNz1X40+yehszDWEbJkneZx7BGKIe9eMT/AN1NSL+PMjOiMyZaqVB2xw==}
 
   '@solidjs/start-devtools@1.0.0-next.4':
     resolution: {integrity: sha512-RNjndz1PfUicxJi3XHwjoIsu9AHeOhpP8Y/bgRmumR5Z9ymdMsiRCL89Fq1YqxhBnHf+GL4kX/VvC+F8lgmTVA==}
@@ -1416,13 +1427,18 @@ packages:
       '@solidjs/web': '>=2.0.0'
       solid-js: '>=2.0.0'
 
-  '@solidjs/web@2.0.0-rc.5':
-    resolution: {integrity: sha512-0Q9QNJXgXDTl4dH8Nr972XdL3ET+GBV/UlxhBG1ZV7U54/PP2yhTJggWxubJNqfeWel8p/W8laNgtS3nLiZpbw==}
+  '@solidjs/web@2.0.0-rc.6':
+    resolution: {integrity: sha512-JgQ2NCjygQpZizZrVjcwPqH3dhIZQZoMRGoGSC6+Tr622cvbuXthDC3pKdNMsjCKCVp19UbT0kkPX15FOdT0pw==}
     peerDependencies:
-      solid-js: ^2.0.0-rc.5
+      solid-js: ^2.0.0-rc.6
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@sveltejs/acorn-typescript@1.0.13':
+    resolution: {integrity: sha512-wgKggnhZVL9Bfx1OaKKTrYY9BFRk6C8UAkQNUcIv1+llzYrIqy+RZm5HPKzn0NpEBvTVhTqB4kQyllZywsRBRQ==}
+    peerDependencies:
+      acorn: ^8.9.0
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -1440,6 +1456,12 @@ packages:
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
+
+  '@tsrx/core@0.1.63':
+    resolution: {integrity: sha512-EQIkCcqW7wTLtLGQQP8bRUe9O+GYFpBsZXXgs7088YIjtoHlNAE2qVgtsEPYY86oV5XBY9aGWLsjCS0SzXvLqw==}
+
+  '@tsrx/runtime@0.1.2':
+    resolution: {integrity: sha512-bhiacN/1cDKtBAY/sePUmRldkj5TvAXk8gqlyCxF22XM7l+gM0FIISDDSg0jIa1pcBfnyW2vnc82WdtfO9h7Ng==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -1464,6 +1486,9 @@ packages:
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -1525,6 +1550,11 @@ packages:
 
   '@vitest/utils@4.1.11':
     resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
+
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -1920,6 +1950,14 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  esrap@2.3.6:
+    resolution: {integrity: sha512-yc0OC12UjPqLoc+fe+v5GNs4TOjAigUw3sTikfC+xeBPGUw7gDRz3DtYaqEhxyMVJojcSWJw7jT0QWR+CbuE/A==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
+
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
@@ -2189,6 +2227,9 @@ packages:
 
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
+
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -2798,8 +2839,8 @@ packages:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
     engines: {node: '>=10'}
 
-  solid-js@2.0.0-rc.5:
-    resolution: {integrity: sha512-AI9ndOlUtXXeFf0/MUADM5HfMYwXtxfitIayOkjBCZl67ZyD4ct5+4kqv0EF2xeyIrUwlsrFTuKpHs54BNA6iw==}
+  solid-js@2.0.0-rc.6:
+    resolution: {integrity: sha512-Z/M8s9ypLBf+6Bl3AAb5upgkYCl73HkpM+UxdUJ5uFGctTwpOQVCM9Gpj3Mjbiaki270HHUfA3Z0Lyn4w+fDtg==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -3160,6 +3201,9 @@ packages:
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+
+  zimmerframe@1.1.5:
+    resolution: {integrity: sha512-msJxIvYDYcoNL+PJsu+7qmpDWsYmAxTY+2TNYXXF0hzBzBk0BMecOqDOG/EckUoKCuKwObfbugIl8QpqHDXeFA==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -4216,6 +4260,8 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@noble/hashes@2.4.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -4399,7 +4445,7 @@ snapshots:
       kleur: 4.1.5
       yargs-parser: 20.2.9
 
-  '@solidjs/babel-plugin@2.0.0-rc.5(@babel/core@7.29.7)':
+  '@solidjs/babel-plugin@2.0.0-rc.6(@babel/core@7.29.7)(@tsrx/core@0.1.63)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.18.6
@@ -4408,64 +4454,70 @@ snapshots:
       html-entities: 2.3.3
       parse5: 7.3.0
       validate-html-nesting: 1.2.4
+    optionalDependencies:
+      '@tsrx/core': 0.1.63
 
-  '@solidjs/compiler-darwin-arm64@2.0.0-rc.5':
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.6':
     optional: true
 
-  '@solidjs/compiler-darwin-x64@2.0.0-rc.5':
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.6':
     optional: true
 
-  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.5':
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.6':
     optional: true
 
-  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.5':
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.6':
     optional: true
 
-  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.5':
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.6':
     dependencies:
       '@emnapi/core': 1.11.3
       '@emnapi/runtime': 1.11.3
       '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     optional: true
 
-  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.5':
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.6':
     optional: true
 
-  '@solidjs/compiler@2.0.0-rc.5':
+  '@solidjs/compiler@2.0.0-rc.6':
     optionalDependencies:
-      '@solidjs/compiler-darwin-arm64': 2.0.0-rc.5
-      '@solidjs/compiler-darwin-x64': 2.0.0-rc.5
-      '@solidjs/compiler-linux-arm64-gnu': 2.0.0-rc.5
-      '@solidjs/compiler-linux-x64-gnu': 2.0.0-rc.5
-      '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.5
-      '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.5
+      '@solidjs/compiler-darwin-arm64': 2.0.0-rc.6
+      '@solidjs/compiler-darwin-x64': 2.0.0-rc.6
+      '@solidjs/compiler-linux-arm64-gnu': 2.0.0-rc.6
+      '@solidjs/compiler-linux-x64-gnu': 2.0.0-rc.6
+      '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.6
+      '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.6
 
-  '@solidjs/diagnostics@2.0.0-rc.5(vitest@4.1.11)':
+  '@solidjs/diagnostics@2.0.0-rc.6(vitest@4.1.11)':
     dependencies:
-      '@solidjs/signals': 2.0.0-rc.5
+      '@solidjs/signals': 2.0.0-rc.6
     optionalDependencies:
       vitest: 4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(jsdom@26.1.0)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2))
 
-  '@solidjs/signals@2.0.0-rc.5': {}
+  '@solidjs/signals@2.0.0-rc.6': {}
 
-  '@solidjs/start-devtools@1.0.0-next.4(@solidjs/web@2.0.0-rc.5(solid-js@2.0.0-rc.5))(solid-js@2.0.0-rc.5)':
+  '@solidjs/start-devtools@1.0.0-next.4(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.5(solid-js@2.0.0-rc.5)
-      solid-js: 2.0.0-rc.5
+      '@solidjs/web': 2.0.0-rc.6(solid-js@2.0.0-rc.6)
+      solid-js: 2.0.0-rc.6
 
-  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.5(solid-js@2.0.0-rc.5))(solid-js@2.0.0-rc.5)':
+  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6))(solid-js@2.0.0-rc.6)':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.5(solid-js@2.0.0-rc.5)
+      '@solidjs/web': 2.0.0-rc.6(solid-js@2.0.0-rc.6)
       '@testing-library/dom': 10.4.1
-      solid-js: 2.0.0-rc.5
+      solid-js: 2.0.0-rc.6
 
-  '@solidjs/web@2.0.0-rc.5(solid-js@2.0.0-rc.5)':
+  '@solidjs/web@2.0.0-rc.6(solid-js@2.0.0-rc.6)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-rc.5
+      solid-js: 2.0.0-rc.6
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@sveltejs/acorn-typescript@1.0.13(acorn@8.18.0)':
+    dependencies:
+      acorn: 8.18.0
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -4491,6 +4543,24 @@ snapshots:
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
+
+  '@tsrx/core@0.1.63':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@noble/hashes': 2.4.0
+      '@sveltejs/acorn-typescript': 1.0.13(acorn@8.18.0)
+      '@tsrx/runtime': 0.1.2
+      '@types/estree': 1.0.9
+      '@types/estree-jsx': 1.0.5
+      acorn: 8.18.0
+      esrap: 2.3.6
+      is-reference: 3.0.3
+      magic-string: 0.30.21
+      zimmerframe: 1.1.5
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
+
+  '@tsrx/runtime@0.1.2': {}
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -4526,6 +4596,10 @@ snapshots:
       assertion-error: 2.0.1
 
   '@types/deep-eql@4.0.2': {}
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.9
 
   '@types/estree@1.0.9': {}
 
@@ -4616,6 +4690,8 @@ snapshots:
       '@vitest/pretty-format': 4.1.11
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
+
+  acorn@8.18.0: {}
 
   agent-base@7.1.4: {}
 
@@ -5024,6 +5100,10 @@ snapshots:
 
   esprima@4.0.1: {}
 
+  esrap@2.3.6:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
@@ -5306,6 +5386,10 @@ snapshots:
   is-potential-custom-element-name@1.0.1: {}
 
   is-reference@1.2.1:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
 
@@ -5880,9 +5964,9 @@ snapshots:
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
 
-  solid-js@2.0.0-rc.5:
+  solid-js@2.0.0-rc.6:
     dependencies:
-      '@solidjs/signals': 2.0.0-rc.5
+      '@solidjs/signals': 2.0.0-rc.6
       csstype: 3.2.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
@@ -6141,5 +6225,7 @@ snapshots:
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
+
+  zimmerframe@1.1.5: {}
 
   zod@4.4.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,26 +8,27 @@ allowBuilds:
   msw: true
 
 catalog:
-  solid-js: "^2.0.0-rc.5"
-  "@solidjs/web": "^2.0.0-rc.5"
+  solid-js: "^2.0.0-rc.6"
+  "@solidjs/web": "^2.0.0-rc.6"
 
 ignoredBuiltDependencies:
   - cypress
 
 minimumReleaseAgeExclude:
-  - '@solidjs/signals@2.0.0-beta.30 || 2.0.0-beta.31 || 2.0.0-beta.32 || 2.0.0-rc.0 || 2.0.0-rc.1 || 2.0.0-rc.2 || 2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5'
+  - '@solidjs/signals@2.0.0-beta.30 || 2.0.0-beta.31 || 2.0.0-beta.32 || 2.0.0-rc.0 || 2.0.0-rc.1 || 2.0.0-rc.2 || 2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6'
   - '@solidjs/start-devtools@1.0.0-next.1 || 1.0.0-next.2 || 1.0.0-next.3'
-  - '@solidjs/web@2.0.0-beta.30 || 2.0.0-beta.31 || 2.0.0-beta.32 || 2.0.0-rc.0 || 2.0.0-rc.1 || 2.0.0-rc.2 || 2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5'
-  - '@solidjs/babel-plugin@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5'
-  - '@solidjs/compiler@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5'
-  - '@solidjs/compiler-darwin-arm64@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5'
-  - '@solidjs/compiler-darwin-x64@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5'
-  - '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5'
-  - '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5'
-  - '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5'
-  - '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5'
-  - '@solidjs/diagnostics@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5'
-  - solid-js@2.0.0-beta.30 || 2.0.0-beta.31 || 2.0.0-beta.32 || 2.0.0-rc.0 || 2.0.0-rc.1 || 2.0.0-rc.2 || 2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5
+  - '@solidjs/web@2.0.0-beta.30 || 2.0.0-beta.31 || 2.0.0-beta.32 || 2.0.0-rc.0 || 2.0.0-rc.1 || 2.0.0-rc.2 || 2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6'
+  - '@solidjs/babel-plugin@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6'
+  - '@solidjs/compiler@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6'
+  - '@solidjs/compiler-darwin-arm64@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6'
+  - '@solidjs/compiler-darwin-x64@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6'
+  - '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6'
+  - '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6'
+  - '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6'
+  - '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6'
+  - '@solidjs/diagnostics@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6'
+  - '@tsrx/core@0.1.63'
+  - solid-js@2.0.0-beta.30 || 2.0.0-beta.31 || 2.0.0-beta.32 || 2.0.0-rc.0 || 2.0.0-rc.1 || 2.0.0-rc.2 || 2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6
   - '@dom-expressions/babel-plugin-jsx@0.50.0-next.35 || 0.50.0-next.37 || 0.50.0-next.40 || 0.50.0-next.43'
   - '@dom-expressions/compiler-darwin-arm64@0.50.0-next.35 || 0.50.0-next.37 || 0.50.0-next.40 || 0.50.0-next.43'
   - '@dom-expressions/compiler-darwin-x64@0.50.0-next.35 || 0.50.0-next.37 || 0.50.0-next.40 || 0.50.0-next.43'

--- a/src/dev-manifest.ts
+++ b/src/dev-manifest.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import type { DevEnvironment, EnvironmentModuleNode, ViteDevServer } from 'vite';
 import { joinBase } from './http.js';
+import { isTsrxCssModule } from './tsrx.js';
 
 /**
  * Dev-mode asset resolution: the `virtual:solid-manifest` module exports a
@@ -155,6 +156,10 @@ const nonAmbientQueryRegExp = /[?&](url|inline|raw)\b/;
 
 const NULL_BYTE_PLACEHOLDER = '/@id/__x00__';
 
+function isCssModuleUrl(url: string): boolean {
+  return cssFileRegExp.test(url.split('?')[0]!) || isTsrxCssModule(url);
+}
+
 // Per Vite's convention virtual module ids are prefixed with `\0`, which
 // cannot appear in an HTML attribute (the parser replaces it). Serialize the
 // same placeholder form Vite's own URLs use. Adoption of virtual-module
@@ -227,7 +232,7 @@ async function collectModuleDeps(
   if (!node?.id || deps.has(node)) return;
   deps.add(node);
 
-  const isCss = cssFileRegExp.test(node.url.split('?')[0]);
+  const isCss = isCssModuleUrl(node.url);
   if (!isCss && node.file && !node.id.startsWith('\0') && !filter(node.file)) return;
   if (node.file) onFile?.(node.file);
   if (isCss) return;
@@ -267,8 +272,7 @@ export async function collectDevStyleSources(
   const seen = new Set<string>();
   for (const node of deps) {
     if (!node.id) continue;
-    const cleanUrl = node.url.split('?')[0];
-    if (!cssFileRegExp.test(cleanUrl) || nonAmbientQueryRegExp.test(node.url)) continue;
+    if (!isCssModuleUrl(node.url) || nonAmbientQueryRegExp.test(node.url)) continue;
     const id = wrapId(node.id);
     if (seen.has(id)) continue;
     seen.add(id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,17 @@ import { solidDiagnostics } from './diagnostics/index.js';
 import { serverFunctions, type ServerFunctionsOptions } from './server-functions/index.js';
 import { SSR_HANDLER_ID, startServe, type StartOptions } from './ssr/index.js';
 import { startEnv } from './start-env.js';
+import {
+  cleanModuleId,
+  isTsrxCssModule,
+  isTsrxModule,
+  offsetSourceMapLine,
+  prependTsrxCssImport,
+  resolvedTsrxCssModuleId,
+  resolveTsrxCssModule,
+  tsrxCssSourceId,
+  updateTsrxCss,
+} from './tsrx.js';
 
 export { devStylePatch } from './dev-manifest.js';
 export { serverFunctions };
@@ -31,6 +42,7 @@ import {
   defaultClientConditions,
   defaultExternalConditions,
   defaultServerConditions,
+  transformWithOxc,
 } from 'vite';
 import { getEnvironmentConsumer, isRunnableEnvironment } from './environment.js';
 import { crawlFrameworkPkgs } from 'vitefu';
@@ -334,7 +346,8 @@ export interface Options {
   hot?: boolean;
   /**
    * This registers additional extensions that should be processed by
-   * @solidjs/vite-plugin.
+   * @solidjs/vite-plugin. Experimental `.tsrx` is always registered as
+   * TypeScript TSRX and does not need to be listed here.
    *
    * @default undefined
    */
@@ -346,7 +359,8 @@ export interface Options {
    * Note: with `compiler: "native"` the plugin is normally fully Babel-free
    * (native lazy/refresh/JSX passes). Supplying custom babel options
    * reintroduces a Babel support pass ahead of the native JSX transform to
-   * host them.
+   * host them. For `.tsrx` only, native TSRX lowering runs first and the
+   * support pass receives the generated ordinary JavaScript.
    *
    * @default {}
    */
@@ -628,6 +642,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
   let base = '/';
   let clientOutDir: string | null = null;
   let solidPkgsConfig: Awaited<ReturnType<typeof crawlFrameworkPkgs>>;
+  const tsrxCss = new Map<string, string>();
 
   // The client build's manifest, read back by SSR builds. In builder-mode
   // (single process, e.g. SolidStart's nitro plugin) the client build runs
@@ -718,6 +733,48 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
     const query = queryIndex === -1 ? '' : id.slice(queryIndex);
     const relativeId = path.relative(projectRoot, file).split(path.sep).join('/') + query;
     return code + `\nexport const $$moduleUrl = ${JSON.stringify(relativeId)};\n`;
+  }
+
+  function nativeTsrxCss(result: unknown): string {
+    const css = (result as { css?: unknown }).css;
+    return typeof css === 'string' ? css : '';
+  }
+
+  function babelTsrxCss(result: babel.BabelFileResult): string {
+    const css = (result.metadata as { css?: unknown } | undefined)?.css;
+    return typeof css === 'string' ? css : '';
+  }
+
+  async function compileTsrxCss(source: string, id: string): Promise<string> {
+    const solidOptions = getSolidOptions(options, false, replaceDev, isTestMode);
+    if (options.compiler === 'babel') {
+      const babelUserOptions = await getBabelUserOptions(options, source, id, false);
+      const babelOptions = mergeAndConcat(babelUserOptions, {
+        root: projectRoot,
+        // Keep .tsrx: the Babel plugin uses it to select its TSRX parser.
+        filename: id,
+        sourceFileName: id,
+        ast: false,
+        code: false,
+        sourceMaps: false,
+        configFile: false,
+        babelrc: false,
+        parserOpts: {
+          plugins: ['jsx', 'decorators', 'typescript'],
+        },
+        plugins: [[solid, solidOptions]],
+      }) as babel.TransformOptions;
+      const result = await babel.transformAsync(source, babelOptions);
+      return result ? babelTsrxCss(result) : '';
+    }
+
+    const compiler = await loadNativeCompiler();
+    const result = await compiler.transformAsync(source, {
+      ...solidOptions,
+      filename: id,
+      sourceMap: false,
+    });
+    return nativeTsrxCss(result);
   }
 
   const mainPlugin: Plugin = {
@@ -815,6 +872,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
           dedupe: nestedDeps,
         },
         optimizeDeps: {
+          extensions: ['.tsrx'],
           include: [
             ...nestedDeps,
             // Dev refresh wrappers import the solid-js/refresh runtime in
@@ -837,7 +895,29 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
           ],
           exclude: solidPkgsConfig.optimizeDeps.exclude,
           // Keep Solid TSX from injecting React's automatic runtime during scanning.
-          rolldownOptions: { transform: { jsx: { runtime: 'classic' as const } } },
+          rolldownOptions: {
+            transform: { jsx: { runtime: 'classic' as const } },
+            plugins: [
+              {
+                name: 'solid:tsrx-dep-scan',
+                async transform(source: string, id: string) {
+                  if (!isTsrxModule(id) || isTsrxCssModule(id)) return null;
+                  const compiler = await loadNativeCompiler();
+                  const result = await compiler.transformAsync(source, {
+                    ...getSolidOptions(options, false, replaceDev, isTestMode),
+                    filename: cleanModuleId(id),
+                    sourceMap: false,
+                  });
+                  const stripped = await transformWithOxc(result.code, cleanModuleId(id) + '.tsx', {
+                    lang: 'tsx',
+                    sourcemap: false,
+                    target: 'esnext',
+                  });
+                  return { code: stripped.code, map: null };
+                },
+              },
+            ],
+          },
         },
         ...(Object.keys(test).length ? { test } : {}),
       };
@@ -964,7 +1044,17 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
       } as typeof hot.send;
     },
 
-    hotUpdate({ modules, file }) {
+    async hotUpdate({ file, modules, read }) {
+      if (isTsrxModule(file) && this.environment.name === 'client') {
+        updateTsrxCss(tsrxCss, file, await compileTsrxCss(await read(), file));
+        const cssModule = this.environment.moduleGraph.getModuleById(resolvedTsrxCssModuleId(file));
+        if (cssModule) {
+          this.environment.moduleGraph.invalidateModule(cssModule);
+          if (!modules.includes(cssModule)) modules = [...modules, cssModule];
+          return modules;
+        }
+      }
+
       // solid-refresh only injects HMR boundaries into client modules, so
       // non-client environments have no accept handlers. Without this, Vite
       // would see no boundaries and send full-reload messages that race with
@@ -998,6 +1088,8 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
     },
 
     resolveId(id) {
+      const tsrxCssId = resolveTsrxCssModule(id);
+      if (tsrxCssId) return tsrxCssId;
       if (id === VIRTUAL_MANIFEST_ID) return RESOLVED_VIRTUAL_MANIFEST_ID;
     },
 
@@ -1011,7 +1103,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
       for (const depId of info.dynamicallyImportedIds || []) {
         const cleanId = depId.split('?')[0];
         if (/node_modules/.test(cleanId) || cleanId.startsWith('\0')) continue;
-        if (!/\.[mc]?[tj]sx?$/i.test(cleanId)) continue;
+        if (!(/\.[mc]?[tj]sx?$/i.test(cleanId) || isTsrxModule(cleanId))) continue;
         if (emittedLazyChunks.has(depId)) continue;
         emittedLazyChunks.add(depId);
         emittedLazyChunkRefs.push(
@@ -1021,6 +1113,8 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
     },
 
     load(id) {
+      const tsrxSource = tsrxCssSourceId(id);
+      if (tsrxSource) return tsrxCss.get(tsrxSource) ?? '';
       if (id === RESOLVED_VIRTUAL_MANIFEST_ID) {
         if (!isBuild) {
           return devManifestCode(
@@ -1068,6 +1162,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
     },
 
     async transform(source, id, transformOptions) {
+      if (isTsrxCssModule(id)) return null;
       const isSsr = getEnvironmentConsumer(this.environment, transformOptions) === 'server';
       const currentFileExtension = getExtension(id);
 
@@ -1086,8 +1181,9 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
       // while the transform pipeline below works on the clean file path.
       const moduleId = id;
       id = id.replace(/\?.*$/, '');
+      const isTsrx = isTsrxModule(id);
 
-      if (!(/\.[mc]?[tj]sx$/i.test(id) || allExtensions.includes(currentFileExtension))) {
+      if (!(/\.[mc]?[tj]sx$/i.test(id) || isTsrx || allExtensions.includes(currentFileExtension))) {
         return null;
       }
 
@@ -1097,6 +1193,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
       // We need to know if the current file extension has a typescript options tied to it
       const shouldBeProcessedWithTypescript =
         /\.[mc]?tsx$/i.test(id) ||
+        isTsrx ||
         extensionsToWatch.some((extension) => {
           if (typeof extension === 'string') {
             return extension.includes('tsx');
@@ -1128,9 +1225,10 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
       // extension; custom extensions registered through `options.extensions`
       // are unknown to it, so borrow a standard one matching the configured
       // TypeScript-ness.
-      const nativeFilename = /\.(?:[mc]?[jt]s|[jt]sx)$/i.test(id)
-        ? id
-        : id + (shouldBeProcessedWithTypescript ? '.tsx' : '.jsx');
+      const nativeFilename =
+        isTsrx || /\.(?:[mc]?[jt]s|[jt]sx)$/i.test(id)
+          ? id
+          : id + (shouldBeProcessedWithTypescript ? '.tsx' : '.jsx');
 
       // Shared native prelude for every mode: the lazy() module-URL pass,
       // then (dev/client/non-node_modules) the solid-refresh HMR pass, both
@@ -1140,6 +1238,111 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
       const compiler = await loadNativeCompiler();
       let code = source;
       const maps: ChainableMap[] = [];
+
+      if (isTsrx) {
+        // Solid lowering preserves authored TypeScript annotations; secondary
+        // passes therefore parse the generated module as TSX even though no
+        // template syntax remains.
+        const generatedFilename = id + '.tsx';
+        const babelBaseOptions: babel.TransformOptions = {
+          root: projectRoot,
+          filename: id,
+          sourceFileName: id,
+          ast: false,
+          sourceMaps: true,
+          configFile: false,
+          babelrc: false,
+          parserOpts: {
+            plugins,
+          },
+        };
+        let css = '';
+
+        if (options.compiler !== 'babel') {
+          const result = await compiler.transformAsync(code, {
+            ...solidOptions,
+            filename: id,
+            sourceMap: true,
+          });
+          code = result.code || '';
+          css = nativeTsrxCss(result);
+          maps.push(result.map);
+
+          if (options.babel) {
+            // The support pass cannot parse authored TSRX. On this route it
+            // intentionally sees the lowered ordinary JavaScript instead.
+            const supportOptions = mergeAndConcat(
+              babelUserOptions,
+              babelBaseOptions,
+            ) as babel.TransformOptions;
+            // This pass sees native-lowered ordinary JavaScript, so do not
+            // route it back through Babel's TSRX parser.
+            supportOptions.filename = generatedFilename;
+            const supportResult = await babel.transformAsync(code, supportOptions);
+            if (!supportResult) return undefined;
+            code = supportResult.code || '';
+            maps.push(supportResult.map);
+          }
+        } else {
+          const babelOptions = mergeAndConcat(babelUserOptions, {
+            ...babelBaseOptions,
+            plugins: [[solid, solidOptions]],
+          }) as babel.TransformOptions;
+          const result = await babel.transformAsync(code, babelOptions);
+          if (!result) return undefined;
+          code = result.code || '';
+          css = babelTsrxCss(result);
+          maps.push(result.map);
+        }
+
+        const lazyResult = await compiler.transformLazyAsync(code, {
+          filename: generatedFilename,
+          sourceMap: true,
+        });
+        code = lazyResult.code;
+        maps.push(lazyResult.map);
+
+        if (needRefresh) {
+          const refreshResult = await compiler.transformRefreshAsync(code, {
+            filename: generatedFilename,
+            bundler: 'vite',
+            fixRender: true,
+            ...(typeof options.refresh?.granular === 'boolean'
+              ? { granular: options.refresh.granular }
+              : {}),
+            jsx: false,
+            importSource: REFRESH_RUNTIME_SOURCE,
+            sourceMap: true,
+          });
+          code = refreshResult.code;
+          maps.push(refreshResult.map);
+        }
+
+        code = injectSsrModuleId(await resolveLazyModuleUrls(this, code, id), moduleId, !!isSsr);
+        let map = options.compiler === 'babel' ? combineSourcemaps(maps) : null;
+        updateTsrxCss(tsrxCss, id, css);
+        if (css) {
+          code = prependTsrxCssImport(code, id);
+          map = offsetSourceMapLine(map);
+        }
+        // Vite selects its TypeScript stripping by file extension. Since the
+        // real module identity remains `.tsrx`, strip the annotations here
+        // after Solid lowering instead of handing typed JavaScript to Rollup.
+        const stripped = await transformWithOxc(
+          code,
+          generatedFilename,
+          {
+            lang: 'tsx',
+            sourcemap: map != null,
+            target: 'esnext',
+          },
+          map ?? undefined,
+        );
+        return {
+          code: stripped.code,
+          map: map == null ? null : stripped.map,
+        };
+      }
 
       const lazyResult = await compiler.transformLazyAsync(code, {
         filename: nativeFilename,
@@ -1243,24 +1446,31 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
     },
   };
 
-  // The directive transform must run before the JSX transform (it operates
-  // on raw directives, and client-mode module-level extraction must happen
-  // before templates are generated), so its sub-plugins go first. The
-  // boundary markers (`server-only` / `client-only`) are always on.
-  const plugins: Plugin[] = options.serverFunctions
-    ? [
-        boundaryModules(),
-        ...serverFunctions(options.serverFunctions === true ? {} : options.serverFunctions, {
-          devMiddleware: true,
-          externalDevServer,
-          // With start mode on (either variant), the dev middleware dispatches
-          // the endpoint through the SSR handler so user middleware and the
-          // stub-backed request event front it exactly like page SSR.
-          ...(startOptions ? { ssrHandler: SSR_HANDLER_ID } : {}),
-        }),
-        mainPlugin,
-      ]
-    : [boundaryModules(), mainPlugin];
+  // Ordinary modules need the directive transform before JSX. Authored TSRX
+  // cannot be parsed by that standalone pass, so its companion compiler runs
+  // after mainPlugin has lowered the file to ordinary JavaScript while keeping
+  // the original .tsrx id for stable server-function hashes.
+  const serverFunctionPlugins = options.serverFunctions
+    ? serverFunctions(options.serverFunctions === true ? {} : options.serverFunctions, {
+        devMiddleware: true,
+        externalDevServer,
+        tsrxAfterSolid: true,
+        tsrxSourceMap: options.compiler === 'babel',
+        // With start mode on (either variant), the dev middleware dispatches
+        // the endpoint through the SSR handler so user middleware and the
+        // stub-backed request event front it exactly like page SSR.
+        ...(startOptions ? { ssrHandler: SSR_HANDLER_ID } : {}),
+      })
+    : [];
+  const tsrxServerFunctionPlugin = serverFunctionPlugins.find(
+    (plugin) => plugin.name === 'solid:server-functions/tsrx-compiler',
+  );
+  const plugins: Plugin[] = [
+    boundaryModules(),
+    ...serverFunctionPlugins.filter((plugin) => plugin !== tsrxServerFunctionPlugin),
+    mainPlugin,
+    ...(tsrxServerFunctionPlugin ? [tsrxServerFunctionPlugin] : []),
+  ];
 
   // The `start` option opts into start-mode serving on top of the transforms;
   // the `ssr` boolean picks the mode (a bare `ssr: true` keeps the

--- a/src/server-functions/compile.ts
+++ b/src/server-functions/compile.ts
@@ -24,6 +24,8 @@ export interface CompileOptions {
   directive: string;
   /** Project root; function IDs hash the root-relative path. */
   root: string;
+  /** Whether to emit a map for this pass. Defaults to true. */
+  sourceMap?: boolean;
   definitions: {
     register: ImportDefinition;
     create: ImportDefinition;
@@ -80,7 +82,7 @@ export async function compile(
     mode: options.mode,
     env: options.env,
     directive: options.directive,
-    sourceMap: true,
+    sourceMap: options.sourceMap !== false,
     register: options.definitions.register,
     create: options.definitions.create,
   });

--- a/src/server-functions/index.ts
+++ b/src/server-functions/index.ts
@@ -19,6 +19,7 @@ import {
 } from 'vite';
 import { getEnvironmentConsumer, isRunnableEnvironment } from '../environment.js';
 import { joinBase, sendWebResponse, webRequestFromNode } from '../http.js';
+import { isTsrxModule } from '../tsrx.js';
 import { compile, type CompileOptions } from './compile.js';
 import xxHash32 from './xxhash32.js';
 
@@ -28,7 +29,7 @@ import xxHash32 from './xxhash32.js';
  * root — not the invocation directory — so running `vite` from outside the
  * project keeps compiling the same files. Absolute patterns are used as-is.
  *
- * @default include "src/**\/*.{jsx,tsx,ts,js,mjs,cjs}", exclude "node_modules/**\/*.{jsx,tsx,ts,js,mjs,cjs}"
+ * @default include "src/**\/*.{jsx,tsx,tsrx,ts,js,mjs,cjs}", exclude "node_modules/**\/*.{jsx,tsx,tsrx,ts,js,mjs,cjs}"
  */
 export interface ServerFunctionsFilter {
   include?: FilterPattern;
@@ -155,8 +156,8 @@ export interface ServerFunctionsOptions {
   components?: boolean;
 }
 
-const DEFAULT_INCLUDE = 'src/**/*.{jsx,tsx,ts,js,mjs,cjs}';
-const DEFAULT_EXCLUDE = 'node_modules/**/*.{jsx,tsx,ts,js,mjs,cjs}';
+const DEFAULT_INCLUDE = 'src/**/*.{jsx,tsx,tsrx,ts,js,mjs,cjs}';
+const DEFAULT_EXCLUDE = 'node_modules/**/*.{jsx,tsx,tsrx,ts,js,mjs,cjs}';
 const DEFAULT_MANIFEST = 'virtual:solid-server-function-manifest';
 const DEFAULT_DIRECTIVE = 'use server';
 const DEFAULT_RUNTIME = '@solidjs/web/server-functions';
@@ -301,7 +302,13 @@ function invalidateModules(
  */
 export function serverFunctions(
   options: ServerFunctionsOptions = {},
-  internal: { devMiddleware?: boolean; externalDevServer?: boolean; ssrHandler?: string } = {},
+  internal: {
+    devMiddleware?: boolean;
+    externalDevServer?: boolean;
+    ssrHandler?: string;
+    tsrxAfterSolid?: boolean;
+    tsrxSourceMap?: boolean;
+  } = {},
 ): Plugin[] {
   const filterInclude = options.filter?.include || DEFAULT_INCLUDE;
   const filterExclude = options.filter?.exclude || DEFAULT_EXCLUDE;
@@ -591,6 +598,63 @@ export function serverFunctions(
     });
   }
 
+  async function transformModule(
+    ctx: any,
+    code: string,
+    fileId: string,
+    opts: unknown,
+    tsrx: boolean,
+  ) {
+    const mode = getEnvironmentConsumer(ctx.environment, opts);
+    const [id] = fileId.split('?');
+    if (!id || !filter(id) || isTsrxModule(id) !== tsrx) return null;
+
+    // The directive has to appear literally, so anything without the
+    // substring can skip the native parse entirely.
+    if (!code.includes(directive)) return null;
+
+    const result = await compile(id, code, {
+      ...(mode === 'server' ? serverOptions : clientOptions),
+      mode,
+      env,
+      root,
+      sourceMap: !tsrx || !!internal.tsrxSourceMap,
+    });
+
+    if (!result.valid) return null;
+
+    const preloader = preload[mode];
+    if (preloader) preloader.defer();
+    invalidateModules(
+      currentServer,
+      mergeManifestRecord(manifest.server, new Set([id])),
+      manifestId,
+    );
+
+    return {
+      // Appended (not prepended) so the source map for the compiled module
+      // stays valid; imports hoist and the endpoint is only read at call time.
+      code: (result.code || '') + endpointConfigureSnippet(mode),
+      map: result.map,
+    };
+  }
+
+  const compilerPlugin: Plugin = {
+    name: 'solid:server-functions/compiler',
+    enforce: 'pre',
+    transform(code, fileId, opts) {
+      return transformModule(this, code, fileId, opts, false);
+    },
+  };
+
+  const tsrxCompilerPlugin: Plugin = {
+    name: 'solid:server-functions/tsrx-compiler',
+    enforce: 'pre',
+    transform(code, fileId, opts) {
+      return transformModule(this, code, fileId, opts, true);
+    },
+  };
+
   return [
     {
       name: 'solid:server-functions/setup',
@@ -671,51 +735,8 @@ export function serverFunctions(
         return null;
       },
     },
-    {
-      name: 'solid:server-functions/compiler',
-      enforce: 'pre',
-      async transform(code, fileId, opts) {
-        const mode = getEnvironmentConsumer(this.environment, opts);
-        const [id] = fileId.split('?');
-        if (!filter(id)) {
-          return null;
-        }
-
-        // Fast path: the directive has to appear literally, so anything
-        // without the substring can skip the native parse entirely.
-        if (!code.includes(directive)) {
-          return null;
-        }
-
-        const result = await compile(id!, code, {
-          ...(mode === 'server' ? serverOptions : clientOptions),
-          mode,
-          env,
-          root,
-        });
-
-        if (result.valid) {
-          const preloader = preload[mode];
-          if (preloader) {
-            preloader.defer();
-          }
-          invalidateModules(
-            currentServer,
-            mergeManifestRecord(manifest.server, new Set([id!])),
-            manifestId,
-          );
-
-          return {
-            // Appended (not prepended) so the source map for the compiled
-            // module stays valid; imports hoist and the endpoint is only
-            // read at call time, never during module evaluation.
-            code: (result.code || '') + endpointConfigureSnippet(mode),
-            map: result.map,
-          };
-        }
-        return null;
-      },
-    },
+    compilerPlugin,
+    ...(internal.tsrxAfterSolid ? [tsrxCompilerPlugin] : []),
     ...startPlugins,
   ];
 }

--- a/src/ssr/index.ts
+++ b/src/ssr/index.ts
@@ -83,7 +83,7 @@ export interface StartOptions {
    * Root component module for generated entries (the zero-config path).
    * Resolved relative to the Vite root.
    *
-   * @default "src/App.{tsx,jsx,ts,js}" (also probes lowercase "src/app.*")
+   * @default "src/App.{tsx,jsx,ts,js,tsrx}" (also probes lowercase "src/app.*")
    */
   app?: string;
   /** Options for development CSS crawling. */
@@ -119,7 +119,7 @@ export interface StartOptions {
    * dev serving and the build-time prerender). Conventional
    * `src/entry-server.*` files are likewise ignored there.
    *
-   * @default "src/entry-server.{tsx,jsx,ts,js,mjs}" when present, else a
+   * @default "src/entry-server.{tsx,jsx,ts,js,mjs,tsrx}" when present, else a
    * generated entry rendering `<Document><App /></Document>`
    */
   entryServer?: string;
@@ -128,7 +128,7 @@ export interface StartOptions {
    * (a generated one calls `render()`), and it stands alone — no pairing
    * rule with a server entry.
    *
-   * @default "src/entry-client.{tsx,jsx,ts,js,mjs}" when present, else a
+   * @default "src/entry-client.{tsx,jsx,ts,js,mjs,tsrx}" when present, else a
    * generated entry
    */
   entryClient?: string;
@@ -140,7 +140,7 @@ export interface StartOptions {
    * Document costs nothing across the flip; the built-in shell omits it per
    * mode). Only used when the server entry is generated.
    *
-   * @default "src/Document.{tsx,jsx}" when present, else a built-in shell
+   * @default "src/Document.{tsx,jsx,tsrx}" when present, else a built-in shell
    */
   document?: string;
   /**
@@ -302,9 +302,9 @@ const MANIFEST_ID = 'virtual:solid-manifest';
 const SERVER_FUNCTION_HANDLER_ID = 'virtual:solid-server-function-handler';
 const STORAGE_SOURCE = '@solidjs/web/storage';
 
-const ENTRY_EXTENSIONS = ['.tsx', '.jsx', '.ts', '.js', '.mjs'];
-const APP_EXTENSIONS = ['.tsx', '.jsx', '.ts', '.js'];
-const DOCUMENT_EXTENSIONS = ['.tsx', '.jsx'];
+const ENTRY_EXTENSIONS = ['.tsx', '.jsx', '.ts', '.js', '.mjs', '.tsrx'];
+const APP_EXTENSIONS = ['.tsx', '.jsx', '.ts', '.js', '.tsrx'];
+const DOCUMENT_EXTENSIONS = ['.tsx', '.jsx', '.tsrx'];
 
 function probe(root: string, stem: string, extensions: string[]): string | null {
   for (const ext of extensions) {

--- a/src/tsrx.ts
+++ b/src/tsrx.ts
@@ -1,0 +1,95 @@
+export const TSRX_CSS_QUERY = '?solid-tsrx-css&lang.css';
+const NULL_BYTE_PLACEHOLDER = '/@id/__x00__';
+
+export function cleanModuleId(id: string): string {
+  const query = id.indexOf('?');
+  return query === -1 ? id : id.slice(0, query);
+}
+
+export function isTsrxModule(id: string): boolean {
+  return cleanModuleId(id).toLowerCase().endsWith('.tsrx');
+}
+
+export function isTsrxCssModule(id: string): boolean {
+  const unwrapped = id.startsWith('\0')
+    ? id.slice(1)
+    : id.startsWith(NULL_BYTE_PLACEHOLDER)
+      ? id.slice(NULL_BYTE_PLACEHOLDER.length)
+      : id;
+  const queryIndex = unwrapped.indexOf('?');
+  if (queryIndex === -1 || !unwrapped.slice(0, queryIndex).toLowerCase().endsWith('.tsrx')) {
+    return false;
+  }
+  const params = unwrapped.slice(queryIndex + 1).split('&');
+  return params.includes('solid-tsrx-css') && params.includes('lang.css');
+}
+
+export function resolveTsrxCssModule(id: string): string | null {
+  if (!isTsrxCssModule(id)) return null;
+  if (id.startsWith('\0')) return id;
+  if (id.startsWith(NULL_BYTE_PLACEHOLDER)) {
+    return '\0' + id.slice(NULL_BYTE_PLACEHOLDER.length);
+  }
+  return '\0' + id;
+}
+
+export function tsrxCssModuleId(id: string): string {
+  return cleanModuleId(id) + TSRX_CSS_QUERY;
+}
+
+export function resolvedTsrxCssModuleId(id: string): string {
+  return '\0' + tsrxCssModuleId(id);
+}
+
+export function tsrxCssSourceId(id: string): string | null {
+  if (!id.startsWith('\0') || !isTsrxCssModule(id)) return null;
+  return cleanModuleId(id.slice(1));
+}
+
+export function updateTsrxCss(
+  cache: Map<string, string>,
+  id: string,
+  css: string | null | undefined,
+): void {
+  const key = cleanModuleId(id);
+  if (css) {
+    cache.set(key, css);
+  } else {
+    cache.delete(key);
+  }
+}
+
+export function prependTsrxCssImport(code: string, id: string): string {
+  return `import ${JSON.stringify(tsrxCssModuleId(id))};\n${code}`;
+}
+
+export function offsetSourceMapLine<T>(map: T): T {
+  if (
+    map &&
+    typeof map === 'object' &&
+    'mappings' in map &&
+    typeof (map as { mappings?: unknown }).mappings === 'string'
+  ) {
+    return {
+      ...map,
+      mappings: ';' + (map as { mappings: string }).mappings,
+    };
+  }
+  if (
+    map &&
+    typeof map === 'object' &&
+    'sections' in map &&
+    Array.isArray((map as { sections?: unknown }).sections)
+  ) {
+    return {
+      ...map,
+      sections: (
+        map as { sections: Array<{ offset: { line: number; column: number } }> }
+      ).sections.map((section) => ({
+        ...section,
+        offset: { ...section.offset, line: section.offset.line + 1 },
+      })),
+    };
+  }
+  return map;
+}


### PR DESCRIPTION
## Summary
- route `.tsrx` modules through the native or Babel Solid compiler and strip retained TypeScript before Vite parses generated modules
- expose compiler CSS sidecars as virtual CSS modules integrated with production extraction, client HMR, and SSR development style collection
- include `.tsrx` in dependency scanning, lazy chunk handling, start entry discovery, and function-level `\"use server\"` processing

Depends on [solidjs/solid#3086](https://github.com/solidjs/solid/pull/3086) and should remain draft until the compiler support ships in a Solid prerelease.

## Test plan
- [x] `pnpm build`
- [x] Vite 8 production build with native compiler
- [x] Vite 8 production build with Babel compiler
- [x] Vite 8 browser test with native compiler
- [x] Vite 8 browser test with Babel compiler
- [x] native and Babel SSR entry builds
- [x] development transform, CSS sidecar, HMR update, source-map, and server-function smoke checks

Made with [Cursor](https://cursor.com)