### PR TITLE
fix: preload modules for data-addressed server function calls

### DIFF
--- a/.changeset/bodyless-post-no-body-stream.md
+++ b/.changeset/bodyless-post-no-body-stream.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/vite-plugin": patch
+---
+
+Only attach a request body in the dev middlewares' Node-to-web bridging when the incoming request actually carries one (Content-Length/Transfer-Encoding, or the h2 END_STREAM flag). An unconditionally attached empty stream made bodyless POSTs — zero-argument scripted server function calls, synthetic dispatches — parse as a present-but-unusable body, which @solidjs/web 2.0.0-rc.5 rejects as malformed (400) instead of ignoring.

--- a/.changeset/dev-middleware-data-address.md
+++ b/.changeset/dev-middleware-data-address.md
@@ -1,0 +1,5 @@
+---
+'@solidjs/vite-plugin': patch
+---
+
+Dev middleware recognizes the scripted transport's data address. Scripted server-function calls now go to `<endpoint>/data/<id>` (solidjs/solid#3094), and the middleware's module-preload step assumed exactly one path segment after the mount — a cold function only client code references would never be evaluated in the SSR environment for a data-addressed call, answering 404 under `vite dev`. Dispatch itself was unaffected (mount matching is prefix-based). The id now parses from behind the literal `data` segment too; a function id spelled `data` still parses at the bare address, since an id occupies exactly one segment.

--- a/.changeset/drop-legacy-server-function-addressing.md
+++ b/.changeset/drop-legacy-server-function-addressing.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/vite-plugin": patch
+---
+
+Drop the retired `X-Server-Function-Id` header and `?id=` addressing fallback from the dev middleware's module-preload path. Addressing is path-only (`<endpoint>/<id>` and `<endpoint>/data/<id>`), matching the runtime's removal of its own transitional shims during the RC.

--- a/.changeset/id-hash-second-segment.md
+++ b/.changeset/id-hash-second-segment.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/vite-plugin": patch
+---
+
+Read the file hash from the second id segment. Server-function ids are now identity-keyed `<name>-<hash>[-<ordinal>]` (solidjs/solid#3109) instead of positional `<hash>-<ordinal>`, so the dev middleware's id-to-module lookup takes the hash from `split('-')[1]` rather than the first segment.

--- a/examples/start-ssr/server.js
+++ b/examples/start-ssr/server.js
@@ -27,7 +27,15 @@ const MIME = {
 function webRequest(req) {
   const url = new URL(req.url || '/', `http://${req.headers.host || `localhost:${port}`}`);
   const method = req.method || 'GET';
-  const body = method === 'GET' || method === 'HEAD' ? undefined : Readable.toWeb(req);
+  // Attach a body only when the request carries one (Content-Length or
+  // Transfer-Encoding, RFC 9112 §6): the runtime treats a present body that
+  // decodes to nothing as malformed since @solidjs/web 2.0.0-rc.5.
+  const hasBody =
+    method !== 'GET' &&
+    method !== 'HEAD' &&
+    (req.headers['transfer-encoding'] !== undefined ||
+      (req.headers['content-length'] !== undefined && req.headers['content-length'] !== '0'));
+  const body = hasBody ? Readable.toWeb(req) : undefined;
   return new Request(url, {
     method,
     headers: req.headers,

--- a/examples/start-ssr/test/host-dispatch.mjs
+++ b/examples/start-ssr/test/host-dispatch.mjs
@@ -23,7 +23,7 @@ try {
   // manifest (the same signal the browser's module request sends in a real
   // session); it also yields the compiled reference to pull the id from.
   const transformed = await server.transformRequest('/src/api.ts');
-  const match = /createServerReference\w*\("([^"]*-getServerMessage)"/.exec(transformed?.code || '');
+  const match = /createServerReference\w*\("(getServerMessage-[^"]*)"/.exec(transformed?.code || '');
   if (!match) throw new Error('could not extract function id from transformed module');
 
   const runner = server.environments.ssr.runner;
@@ -40,7 +40,7 @@ try {
   const body = await response.text();
   console.log(`HOST-DISPATCH ${response.status} ${body}`);
 
-  const nativeMatch = /createServerReference\w*\("([^"]*-nativeAddress)"/.exec(
+  const nativeMatch = /createServerReference\w*\("(nativeAddress-[^"]*)"/.exec(
     transformed?.code || '',
   );
   if (!nativeMatch) throw new Error('could not extract nativeAddress function id');

--- a/examples/start-ssr/test/run.mjs
+++ b/examples/start-ssr/test/run.mjs
@@ -297,25 +297,34 @@ function record(mode, phase, name, ok, detail = '') {
   console.log(`  [${mode}/${phase}] ${status} ${name}${detail && !ok ? ` — ${detail}` : ''}`);
 }
 
-// Dev function IDs are `hash-count-name`; pull the one for `name` out of the
-// client-transformed module so the endpoint can be hit directly.
+// Pull the function id for `name` out of the client-transformed module so
+// the endpoint can be hit directly.
 function extractFunctionId(transformedCode, name) {
-  // The import identifier may be aliased (e.g. createServerReference_1), and
-  // newer compilers pass the function name as a second argument after the id.
-  const match = transformedCode.match(new RegExp(`createServerReference\\w*\\("([^"]*-${name})"`));
+  // The import identifier may be aliased (e.g. createServerReference_1).
+  // Ids are identity-keyed `<name>-<hash>[-<ordinal>]` (solidjs/solid#3109);
+  // the literal `-` after the name keeps e.g. `getServerMessage2` from
+  // matching a probe for `getServerMessage`.
+  const match = transformedCode.match(new RegExp(`createServerReference\\w*\\("(${name}-[^"]*)"`));
   return match ? match[1] : null;
 }
 
-async function runCsrfChecks(mode, origin) {
-  const crossSite = await fetch(origin + '/_server/csrf-probe', {
-    method: 'POST',
-    headers: { 'Sec-Fetch-Site': 'cross-site' },
-  });
+async function runCsrfChecks(mode, origin, registeredId) {
+  // The runtime answers unknown ids 404 before the same-origin check runs
+  // (@solidjs/web 2.0.0-rc.5), so the rejection must be probed against a
+  // registered function id.
+  const crossSite = await fetch(
+    `${origin}/_server/${encodeURIComponent(registeredId || 'csrf-probe')}`,
+    {
+      method: 'POST',
+      headers: { 'Sec-Fetch-Site': 'cross-site' },
+    },
+  );
   record(
     mode,
     'csrf',
     'cross-site server function request rejected',
     crossSite.status === 403,
+    registeredId ? `status ${crossSite.status}` : 'no registered id to probe',
   );
 
   const sameOrigin = await fetch(origin + '/_server/csrf-probe', { method: 'POST' });
@@ -924,7 +933,7 @@ async function runDevMode() {
     );
     const bogus = await fetch(origin + '/_server/bogus-0');
     record(mode, 'sf', 'dev middleware rejects unknown id', bogus.status === 404);
-    await runCsrfChecks(mode, origin);
+    await runCsrfChecks(mode, origin, functionId);
 
     const html = await runSsrChecks(mode, origin);
     record(mode, 'dev', 'Vite client injected into <head>', html.includes('/@vite/client'));
@@ -1192,7 +1201,8 @@ async function runProdMode() {
 
     const bogus = await fetch(origin + '/_server/bogus-0');
     record(mode, 'sf', 'prod handler rejects unknown id', bogus.status === 404);
-    await runCsrfChecks(mode, origin);
+    const registeredId = serverBundle.match(/registerServerReference\w*\("([^"]+)"/)?.[1] ?? null;
+    await runCsrfChecks(mode, origin, registeredId);
 
     const html = await runSsrChecks(mode, origin);
     record(
@@ -1771,10 +1781,10 @@ async function runConfigureMode() {
     });
     captureLog(server);
     await waitForHttp(origin + '/', 30000, { headers: { accept: 'text/html' } });
-    // Production ids are the dev id minus its dev-only trailing `-name`
-    // segment (`hash-count` vs `hash-count-name`), so the dev phase's id
-    // carries over. Dispatch before any page render, like dev.
-    const prodId = functionId ? functionId.replace(/-configureProbe$/, '') : null;
+    // Identity-keyed ids (`<name>-<hash>[-<ordinal>]`, solidjs/solid#3109)
+    // are the same in dev and prod, so the dev phase's id carries over
+    // as-is. Dispatch before any page render, like dev.
+    const prodId = functionId;
     const prod = prodId ? await dispatch(prodId) : null;
     record(
       mode,
@@ -2837,8 +2847,8 @@ async function runMiddlewareMode() {
     });
     captureLog(server);
     await waitForHttp(prodOrigin + '/', 30000, { headers: { accept: 'text/html' } });
-    // Prod ids drop the dev-only trailing `-name` segment.
-    const prodId = functionId ? functionId.replace(/-whoAmI$/, '') : null;
+    // Identity-keyed ids are the same in dev and prod (solidjs/solid#3109).
+    const prodId = functionId;
     await runMiddlewareChecksOverHttp('mw-prod', prodOrigin, prodId);
     await runHttpChecks('mw-prod', prodOrigin);
   } catch (e) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   default:
     '@solidjs/web':
-      specifier: ^2.0.0-rc.4
-      version: 2.0.0-rc.4
+      specifier: ^2.0.0-rc.5
+      version: 2.0.0-rc.5
     solid-js:
-      specifier: ^2.0.0-rc.4
-      version: 2.0.0-rc.4
+      specifier: ^2.0.0-rc.5
+      version: 2.0.0-rc.5
 
 importers:
 
@@ -25,13 +25,13 @@ importers:
         version: 7.29.7
       '@solidjs/babel-plugin':
         specifier: ^2.0.0-rc.3
-        version: 2.0.0-rc.4(@babel/core@7.29.7)
+        version: 2.0.0-rc.5(@babel/core@7.29.7)
       '@solidjs/compiler':
         specifier: ^2.0.0-rc.3
-        version: 2.0.0-rc.4
+        version: 2.0.0-rc.5
       '@solidjs/web':
         specifier: ^2.0.0-rc.0
-        version: 2.0.0-rc.4(solid-js@2.0.0-rc.4)
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       '@testing-library/jest-dom':
         specifier: ^5.16.6 || ^5.17.0 || ^6.*
         version: 6.10.0(@testing-library/dom@10.4.1)
@@ -68,10 +68,10 @@ importers:
         version: 0.2.2
       '@solidjs/diagnostics':
         specifier: ^2.0.0-rc.3
-        version: 2.0.0-rc.4(vitest@4.1.11)
+        version: 2.0.0-rc.5(vitest@4.1.11)
       '@solidjs/start-devtools':
         specifier: ^1.0.0-next.3
-        version: 1.0.0-next.4(@solidjs/web@2.0.0-rc.4(solid-js@2.0.0-rc.4))(solid-js@2.0.0-rc.4)
+        version: 1.0.0-next.4(@solidjs/web@2.0.0-rc.5(solid-js@2.0.0-rc.5))(solid-js@2.0.0-rc.5)
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.3
@@ -98,7 +98,7 @@ importers:
         version: 1.0.0(rollup@4.62.2)
       solid-js:
         specifier: ^2.0.0-rc.0
-        version: 2.0.0-rc.4
+        version: 2.0.0-rc.5
       typescript:
         specifier: ^5.2.2
         version: 5.9.3
@@ -110,10 +110,10 @@ importers:
     dependencies:
       '@solidjs/web':
         specifier: 'catalog:'
-        version: 2.0.0-rc.4(solid-js@2.0.0-rc.4)
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       solid-js:
         specifier: 'catalog:'
-        version: 2.0.0-rc.4
+        version: 2.0.0-rc.5
     devDependencies:
       '@solidjs/vite-plugin':
         specifier: workspace:*
@@ -126,10 +126,10 @@ importers:
     dependencies:
       '@solidjs/web':
         specifier: 'catalog:'
-        version: 2.0.0-rc.4(solid-js@2.0.0-rc.4)
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       solid-js:
         specifier: 'catalog:'
-        version: 2.0.0-rc.4
+        version: 2.0.0-rc.5
     devDependencies:
       '@solidjs/vite-plugin':
         specifier: workspace:*
@@ -142,10 +142,10 @@ importers:
     dependencies:
       '@solidjs/web':
         specifier: 'catalog:'
-        version: 2.0.0-rc.4(solid-js@2.0.0-rc.4)
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       solid-js:
         specifier: 'catalog:'
-        version: 2.0.0-rc.4
+        version: 2.0.0-rc.5
     devDependencies:
       '@solidjs/vite-plugin':
         specifier: workspace:*
@@ -158,10 +158,10 @@ importers:
     dependencies:
       '@solidjs/web':
         specifier: 'catalog:'
-        version: 2.0.0-rc.4(solid-js@2.0.0-rc.4)
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       solid-js:
         specifier: 'catalog:'
-        version: 2.0.0-rc.4
+        version: 2.0.0-rc.5
       valibot:
         specifier: ^1.1.0
         version: 1.4.2(typescript@5.9.3)
@@ -183,10 +183,10 @@ importers:
     dependencies:
       '@solidjs/web':
         specifier: 'catalog:'
-        version: 2.0.0-rc.4(solid-js@2.0.0-rc.4)
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       solid-js:
         specifier: 'catalog:'
-        version: 2.0.0-rc.4
+        version: 2.0.0-rc.5
     devDependencies:
       '@solidjs/vite-plugin':
         specifier: workspace:*
@@ -205,14 +205,14 @@ importers:
     dependencies:
       '@solidjs/web':
         specifier: 'catalog:'
-        version: 2.0.0-rc.4(solid-js@2.0.0-rc.4)
+        version: 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       solid-js:
         specifier: 'catalog:'
-        version: 2.0.0-rc.4
+        version: 2.0.0-rc.5
     devDependencies:
       '@solidjs/testing-library':
         specifier: ^1.0.0-beta.2
-        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.4(solid-js@2.0.0-rc.4))(solid-js@2.0.0-rc.4)
+        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.5(solid-js@2.0.0-rc.5))(solid-js@2.0.0-rc.5)
       '@solidjs/vite-plugin':
         specifier: workspace:*
         version: link:../..
@@ -1355,53 +1355,53 @@ packages:
     resolution: {integrity: sha512-T4Wyi9lUuz0a1C2OHuzqZ0aFOCI0AmaGTb2LP9sHgWdoHXlB3JU02gfBpa0Y081G/gFsJYpQ/R0iCJRzF/nknw==}
     hasBin: true
 
-  '@solidjs/babel-plugin@2.0.0-rc.4':
-    resolution: {integrity: sha512-4RYR4PWAlQIz1dmIyPheaUvVb9EnSIw5KIGsEISmHod5qfT1IPVKgtb9bctyQ5FeDAuc7JcpbkFYN2heLrk6rQ==}
+  '@solidjs/babel-plugin@2.0.0-rc.5':
+    resolution: {integrity: sha512-Wd2cHNSRBxisVXTsl0Nq+21+0DFVYeKLQxnZqQqxCqXM8cEnijv6tfcIUzlSEp3esEyQD0gXnbQpSOyoLkHCwg==}
     peerDependencies:
       '@babel/core': ^7.20.12
 
-  '@solidjs/compiler-darwin-arm64@2.0.0-rc.4':
-    resolution: {integrity: sha512-YR4T15ucsV1Vb4J6yaHxss2hakdcbZ353ye53AhX+FWNayuEhO/Cyjdtb9uS38Dfzysok/rIEQdaeZcaXt+rPA==}
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.5':
+    resolution: {integrity: sha512-rCSbArP+hLkYeUPdw6OisdQD313VxP+oaI7FOLohSx1FfiEOVwyAvKgYqGROe4T0ZZXjgTkSZUKHBzbG468j4A==}
     cpu: [arm64]
     os: [darwin]
 
-  '@solidjs/compiler-darwin-x64@2.0.0-rc.4':
-    resolution: {integrity: sha512-95SkVSyXP2eh7PvPWi+fTeH5aTcTwOUvRV7ubeUrutE4akW3ndq1N8cvg2WZ+LhKrf2pvDO0eSDEZ72I769CLg==}
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.5':
+    resolution: {integrity: sha512-l1P0zal1yKy2k/TNMqnh2jFf7CkCr2Iu/AM45Rai65NW2n7zgPO+2LY6kDKCO/ooU4ZZ3FdnTKpwza6mT1xqUQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.4':
-    resolution: {integrity: sha512-36Ht+EUAVUt8fAxq8zlfPS0+vZ61hfJRJDiX1HDNXvlAwZE1B7FH/ym1wfXrhG1TvrNA63Sjjj5CeccYO2H4Tg==}
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.5':
+    resolution: {integrity: sha512-G2BBNzwIUJHtAxPISMjtMi+IsgyCWfJ29tS4MxfUC+Q4aEykTV55ybItAAffwF9YgeHA6JtQY3iVU002QGJDuw==}
     cpu: [arm64]
     os: [linux]
 
-  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.4':
-    resolution: {integrity: sha512-DSFOQEjfYmmRQ70pNLamRXPNQ+aP+5vyh1rMjSKwAzONt0xB2rcy9Alt02GU38gztW9YN6ZyxM4rwkYe+7MfaQ==}
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.5':
+    resolution: {integrity: sha512-3ckN7cot0FiUiGUSnnKJON+sOJgIS8zuEXUPUv/ijjE+gA9pEepX8u06/DXzvEXkrDzPHGWrFx+v19Aogl+l5g==}
     cpu: [x64]
     os: [linux]
 
-  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.4':
-    resolution: {integrity: sha512-zVxXS+01rbv+0yOp2vaGjIu0om5I1UhhPpzNYeE+AmfpVc2eCWxqDsPai3dIxFDGPTjaJ+npwjKJRmOTaoknRw==}
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.5':
+    resolution: {integrity: sha512-1l35k2lCYtpIV/RZBqpy9y7JNMruGAlMBZVxjIHDxCJDs9vKLue/7WPT0qg7cm3dCqa69hVxRNBQYqRHLa4P2g==}
     engines: {node: '>=14.0.0'}
 
-  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.4':
-    resolution: {integrity: sha512-DkzTHMZXzaiL/KhL76UJWN24pKkkXeLpPYtDxUqX6VaKuOCPDmp/m7GLWSDrqCdF7leuYsig2MuMJTXZRLOkbQ==}
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.5':
+    resolution: {integrity: sha512-ZYumQABKyBWv0iEonwcMnrjOt1cKWdjdBeKc9xQ0eNxqMlJsOQvRFMB3Ow7OS2U2aYKfAIzfcPCKgsXv9JbIvA==}
     cpu: [x64]
     os: [win32]
 
-  '@solidjs/compiler@2.0.0-rc.4':
-    resolution: {integrity: sha512-lKx6Jp1KbHxqO+v+g7cRbm8I1DHx/10Lj8bKG4vmdGnCfSlFbyhCd8cPTLdLV0YVG7GGSzzF5m8NkC9NlfGN5w==}
+  '@solidjs/compiler@2.0.0-rc.5':
+    resolution: {integrity: sha512-DQF24zYiTW4GDhhOTITEjjK1PGvPGx8P3qR6ogWBeaXggeMN6vV2s0oqyrYoJr2g2ufJj1vf2FIdLVDu8Ip7zw==}
 
-  '@solidjs/diagnostics@2.0.0-rc.4':
-    resolution: {integrity: sha512-BF2kb5VKcJIwAAnFvto8MHvshnV/Tn4AyvaGLEm1Jp/RQrsmsR+on2w8EOawA+imZjhIh3azuBmed71tW1HV6w==}
+  '@solidjs/diagnostics@2.0.0-rc.5':
+    resolution: {integrity: sha512-qHOuFoGpyiPgSXP3VktxX7SshVQ3k04y5c3SJEcK2uWRY50Zzdq46iWEmej3ohhY7EFK+lQ1BS7i3rttC9pY7w==}
     peerDependencies:
       vitest: '>=2.0.0'
     peerDependenciesMeta:
       vitest:
         optional: true
 
-  '@solidjs/signals@2.0.0-rc.4':
-    resolution: {integrity: sha512-l7P0g8+2pnNscaIPOGDMhv0boaidGAsvR8QN66JySIWNMvVnuq2ayv7ZnvP+IR00DJC+RqCNnnTG/UCdxf+h8g==}
+  '@solidjs/signals@2.0.0-rc.5':
+    resolution: {integrity: sha512-Ks+97LbyN2vYqPEHWpy2YY+MYgoSCge0kHOUFN/Bzdz1Ex/M9Is1HIyBZGBVhf5y35394List5WWlU44yEnm4w==}
 
   '@solidjs/start-devtools@1.0.0-next.4':
     resolution: {integrity: sha512-RNjndz1PfUicxJi3XHwjoIsu9AHeOhpP8Y/bgRmumR5Z9ymdMsiRCL89Fq1YqxhBnHf+GL4kX/VvC+F8lgmTVA==}
@@ -1416,10 +1416,10 @@ packages:
       '@solidjs/web': '>=2.0.0'
       solid-js: '>=2.0.0'
 
-  '@solidjs/web@2.0.0-rc.4':
-    resolution: {integrity: sha512-acM9W0FByf0aJDMG5kMbHr0BLTjvFIg8lxwLwHzsu3ybWSmsP1FiOOs2RHNItve/AiX+MGR9CQBCazmnfPykEA==}
+  '@solidjs/web@2.0.0-rc.5':
+    resolution: {integrity: sha512-0Q9QNJXgXDTl4dH8Nr972XdL3ET+GBV/UlxhBG1ZV7U54/PP2yhTJggWxubJNqfeWel8p/W8laNgtS3nLiZpbw==}
     peerDependencies:
-      solid-js: ^2.0.0-rc.4
+      solid-js: ^2.0.0-rc.5
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2798,8 +2798,8 @@ packages:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
     engines: {node: '>=10'}
 
-  solid-js@2.0.0-rc.4:
-    resolution: {integrity: sha512-hSkDmtduesjFtvzjNyqLphrqiSvhSD5+njkPQUR+9YEoR60MMWtuv36SbLL4OucI0Ronof3Jc+AsUp0oWffwMg==}
+  solid-js@2.0.0-rc.5:
+    resolution: {integrity: sha512-AI9ndOlUtXXeFf0/MUADM5HfMYwXtxfitIayOkjBCZl67ZyD4ct5+4kqv0EF2xeyIrUwlsrFTuKpHs54BNA6iw==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -4399,7 +4399,7 @@ snapshots:
       kleur: 4.1.5
       yargs-parser: 20.2.9
 
-  '@solidjs/babel-plugin@2.0.0-rc.4(@babel/core@7.29.7)':
+  '@solidjs/babel-plugin@2.0.0-rc.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.18.6
@@ -4409,61 +4409,61 @@ snapshots:
       parse5: 7.3.0
       validate-html-nesting: 1.2.4
 
-  '@solidjs/compiler-darwin-arm64@2.0.0-rc.4':
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.5':
     optional: true
 
-  '@solidjs/compiler-darwin-x64@2.0.0-rc.4':
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.5':
     optional: true
 
-  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.4':
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.5':
     optional: true
 
-  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.4':
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.5':
     optional: true
 
-  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.4':
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.5':
     dependencies:
       '@emnapi/core': 1.11.3
       '@emnapi/runtime': 1.11.3
       '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     optional: true
 
-  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.4':
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.5':
     optional: true
 
-  '@solidjs/compiler@2.0.0-rc.4':
+  '@solidjs/compiler@2.0.0-rc.5':
     optionalDependencies:
-      '@solidjs/compiler-darwin-arm64': 2.0.0-rc.4
-      '@solidjs/compiler-darwin-x64': 2.0.0-rc.4
-      '@solidjs/compiler-linux-arm64-gnu': 2.0.0-rc.4
-      '@solidjs/compiler-linux-x64-gnu': 2.0.0-rc.4
-      '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.4
-      '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.4
+      '@solidjs/compiler-darwin-arm64': 2.0.0-rc.5
+      '@solidjs/compiler-darwin-x64': 2.0.0-rc.5
+      '@solidjs/compiler-linux-arm64-gnu': 2.0.0-rc.5
+      '@solidjs/compiler-linux-x64-gnu': 2.0.0-rc.5
+      '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.5
+      '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.5
 
-  '@solidjs/diagnostics@2.0.0-rc.4(vitest@4.1.11)':
+  '@solidjs/diagnostics@2.0.0-rc.5(vitest@4.1.11)':
     dependencies:
-      '@solidjs/signals': 2.0.0-rc.4
+      '@solidjs/signals': 2.0.0-rc.5
     optionalDependencies:
       vitest: 4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(jsdom@26.1.0)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2))
 
-  '@solidjs/signals@2.0.0-rc.4': {}
+  '@solidjs/signals@2.0.0-rc.5': {}
 
-  '@solidjs/start-devtools@1.0.0-next.4(@solidjs/web@2.0.0-rc.4(solid-js@2.0.0-rc.4))(solid-js@2.0.0-rc.4)':
+  '@solidjs/start-devtools@1.0.0-next.4(@solidjs/web@2.0.0-rc.5(solid-js@2.0.0-rc.5))(solid-js@2.0.0-rc.5)':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.4(solid-js@2.0.0-rc.4)
-      solid-js: 2.0.0-rc.4
+      '@solidjs/web': 2.0.0-rc.5(solid-js@2.0.0-rc.5)
+      solid-js: 2.0.0-rc.5
 
-  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.4(solid-js@2.0.0-rc.4))(solid-js@2.0.0-rc.4)':
+  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.5(solid-js@2.0.0-rc.5))(solid-js@2.0.0-rc.5)':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.4(solid-js@2.0.0-rc.4)
+      '@solidjs/web': 2.0.0-rc.5(solid-js@2.0.0-rc.5)
       '@testing-library/dom': 10.4.1
-      solid-js: 2.0.0-rc.4
+      solid-js: 2.0.0-rc.5
 
-  '@solidjs/web@2.0.0-rc.4(solid-js@2.0.0-rc.4)':
+  '@solidjs/web@2.0.0-rc.5(solid-js@2.0.0-rc.5)':
     dependencies:
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-rc.4
+      solid-js: 2.0.0-rc.5
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -5880,9 +5880,9 @@ snapshots:
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
 
-  solid-js@2.0.0-rc.4:
+  solid-js@2.0.0-rc.5:
     dependencies:
-      '@solidjs/signals': 2.0.0-rc.4
+      '@solidjs/signals': 2.0.0-rc.5
       csstype: 3.2.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,26 +8,26 @@ allowBuilds:
   msw: true
 
 catalog:
-  solid-js: "^2.0.0-rc.4"
-  "@solidjs/web": "^2.0.0-rc.4"
+  solid-js: "^2.0.0-rc.5"
+  "@solidjs/web": "^2.0.0-rc.5"
 
 ignoredBuiltDependencies:
   - cypress
 
 minimumReleaseAgeExclude:
-  - '@solidjs/signals@2.0.0-beta.30 || 2.0.0-beta.31 || 2.0.0-beta.32 || 2.0.0-rc.0 || 2.0.0-rc.1 || 2.0.0-rc.2 || 2.0.0-rc.3 || 2.0.0-rc.4'
+  - '@solidjs/signals@2.0.0-beta.30 || 2.0.0-beta.31 || 2.0.0-beta.32 || 2.0.0-rc.0 || 2.0.0-rc.1 || 2.0.0-rc.2 || 2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5'
   - '@solidjs/start-devtools@1.0.0-next.1 || 1.0.0-next.2 || 1.0.0-next.3'
-  - '@solidjs/web@2.0.0-beta.30 || 2.0.0-beta.31 || 2.0.0-beta.32 || 2.0.0-rc.0 || 2.0.0-rc.1 || 2.0.0-rc.2 || 2.0.0-rc.3 || 2.0.0-rc.4'
-  - '@solidjs/babel-plugin@2.0.0-rc.3 || 2.0.0-rc.4'
-  - '@solidjs/compiler@2.0.0-rc.3 || 2.0.0-rc.4'
-  - '@solidjs/compiler-darwin-arm64@2.0.0-rc.3 || 2.0.0-rc.4'
-  - '@solidjs/compiler-darwin-x64@2.0.0-rc.3 || 2.0.0-rc.4'
-  - '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3 || 2.0.0-rc.4'
-  - '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3 || 2.0.0-rc.4'
-  - '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3 || 2.0.0-rc.4'
-  - '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3 || 2.0.0-rc.4'
-  - '@solidjs/diagnostics@2.0.0-rc.3 || 2.0.0-rc.4'
-  - solid-js@2.0.0-beta.30 || 2.0.0-beta.31 || 2.0.0-beta.32 || 2.0.0-rc.0 || 2.0.0-rc.1 || 2.0.0-rc.2 || 2.0.0-rc.3 || 2.0.0-rc.4
+  - '@solidjs/web@2.0.0-beta.30 || 2.0.0-beta.31 || 2.0.0-beta.32 || 2.0.0-rc.0 || 2.0.0-rc.1 || 2.0.0-rc.2 || 2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5'
+  - '@solidjs/babel-plugin@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5'
+  - '@solidjs/compiler@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5'
+  - '@solidjs/compiler-darwin-arm64@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5'
+  - '@solidjs/compiler-darwin-x64@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5'
+  - '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5'
+  - '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5'
+  - '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5'
+  - '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5'
+  - '@solidjs/diagnostics@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5'
+  - solid-js@2.0.0-beta.30 || 2.0.0-beta.31 || 2.0.0-beta.32 || 2.0.0-rc.0 || 2.0.0-rc.1 || 2.0.0-rc.2 || 2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5
   - '@dom-expressions/babel-plugin-jsx@0.50.0-next.35 || 0.50.0-next.37 || 0.50.0-next.40 || 0.50.0-next.43'
   - '@dom-expressions/compiler-darwin-arm64@0.50.0-next.35 || 0.50.0-next.37 || 0.50.0-next.40 || 0.50.0-next.43'
   - '@dom-expressions/compiler-darwin-x64@0.50.0-next.35 || 0.50.0-next.37 || 0.50.0-next.40 || 0.50.0-next.43'

--- a/src/http.ts
+++ b/src/http.ts
@@ -58,10 +58,22 @@ export function webRequestFromNode(
     signal = controller.signal;
   }
   const method = req.method || 'GET';
-  const body =
-    method === 'GET' || method === 'HEAD'
-      ? undefined
-      : (Readable.toWeb(req) as unknown as ReadableStream);
+  // Only attach a body when the request actually carries one. A web Request
+  // built by the browser for a bodyless POST has `body === null`, and the
+  // runtime keys off that (a present body that decodes to nothing is a 400
+  // since @solidjs/web 2.0.0-rc.5) — so an unconditionally attached (empty)
+  // stream misparses bodyless calls. HTTP/1 signals a body via
+  // Content-Length/Transfer-Encoding (RFC 9112 §6); the h2 compat API sets
+  // `stream.endAfterHeaders` when END_STREAM rode the headers frame.
+  const h2Stream = (req as { stream?: { endAfterHeaders?: boolean } }).stream;
+  const hasBody =
+    method !== 'GET' &&
+    method !== 'HEAD' &&
+    (h2Stream
+      ? !h2Stream.endAfterHeaders
+      : req.headers['transfer-encoding'] !== undefined ||
+        (req.headers['content-length'] !== undefined && req.headers['content-length'] !== '0'));
+  const body = hasBody ? (Readable.toWeb(req) as unknown as ReadableStream) : undefined;
   return new Request(url, {
     method,
     headers,

--- a/src/server-functions/index.ts
+++ b/src/server-functions/index.ts
@@ -558,16 +558,6 @@ export function serverFunctions(
                 // not an address; the runtime handler answers the 404
               }
             }
-            if (!functionId) {
-              // TRANSITIONAL (remove before 3.0 stable): the retired header
-              // and `?id=` addressing, kept only for the RC window where this
-              // plugin meets a @solidjs/web older than the path-addressing
-              // change (solidjs/solid#3076).
-              const headerId = req.headers['x-server-function-id'];
-              functionId =
-                (typeof headerId === 'string' ? headerId.split('#')[0] : undefined) ||
-                url.searchParams.get('id');
-            }
             if (functionId) {
               const entry = moduleForFunctionId(functionId);
               if (entry) await ssrEnvironment.runner.import(moduleDevUrl(entry));

--- a/src/server-functions/index.ts
+++ b/src/server-functions/index.ts
@@ -457,9 +457,11 @@ export function serverFunctions(
     ].join('\n');
   }
 
-  // Function IDs are `xxHash32(root-relative path)-<count>` (see compile.ts),
-  // so the hash segment maps an incoming ID back to its module. Rebuilt
-  // whenever a transform has grown the manifest.
+  // Function IDs are `<name>-<xxHash32(root-relative path)>[-<ordinal>]`
+  // (identity-keyed, solidjs/solid#3109). The name is a JS identifier and
+  // never contains `-`, so the hash is always the second segment and maps
+  // an incoming ID back to its module. Rebuilt whenever a transform has
+  // grown the manifest.
   const hashIndex = new Map<string, string>();
   let hashIndexSize = -1;
   function moduleForFunctionId(functionId: string): string | undefined {
@@ -471,7 +473,7 @@ export function serverFunctions(
       }
       hashIndexSize = manifest.server.size;
     }
-    return hashIndex.get(functionId.split('-', 1)[0]!);
+    return hashIndex.get(functionId.split('-')[1]!);
   }
 
   function moduleDevUrl(entry: string): string {

--- a/src/server-functions/index.ts
+++ b/src/server-functions/index.ts
@@ -515,10 +515,11 @@ export function serverFunctions(
         if (internal.externalDevServer || !isRunnableEnvironment(ssrEnvironment)) {
           return;
         }
-        // A call's address is `<endpoint>/<id>` (solidjs/solid#3076) — the
-        // mount plus exactly one path segment. Bare-mount requests still
-        // reach the runtime handler (it answers 404), so misdirected posts
-        // fail through the endpoint rather than falling through to SSR.
+        // A call's address is `<endpoint>/<id>` — plain HTTP — or
+        // `<endpoint>/data/<id>` — the scripted transport's own path
+        // (solidjs/solid#3076, #3094). Bare-mount requests still reach the
+        // runtime handler (it answers 404), so misdirected posts fail
+        // through the endpoint rather than falling through to SSR.
         const underMount = (pathname: string, mount: string) =>
           pathname === mount || pathname.startsWith(mount + '/');
         server.middlewares.use((req, res, next) => {
@@ -538,9 +539,15 @@ export function serverFunctions(
             // Make sure the referenced module has been evaluated in the SSR
             // environment so its registration exists — functions only client
             // code references are never loaded by the SSR render itself.
-            // The id lives in the path segment after the mount.
+            // The id lives in the path segment after the mount — behind a
+            // literal `data` segment on the scripted transport's address
+            // (solidjs/solid#3094). Segment count keeps the two apart: an id
+            // occupies exactly one segment, so `data/<id>` is only ever a
+            // data address, and a function id spelled `data` still parses at
+            // the bare one.
             const mount = basePrefixed ? resolvedEndpoint : endpoint;
-            const segment = url.pathname.slice(mount.length + 1);
+            let segment = url.pathname.slice(mount.length + 1);
+            if (segment.startsWith('data/')) segment = segment.slice(5);
             let functionId: string | null = null;
             if (segment && !segment.includes('/')) {
               try {

--- a/src/ssr/index.ts
+++ b/src/ssr/index.ts
@@ -1002,7 +1002,8 @@ export function startServe(
     lines.push(``, `async function dispatchRequest(request, event, options) {`);
     if (composeServerFunctions) {
       lines.push(
-        // A call's address is `<endpoint>/<id>` (solidjs/solid#3076); the
+        // A call's address is `<endpoint>/<id>` or `<endpoint>/data/<id>`
+        // (solidjs/solid#3076, #3094); the prefix gate covers both, and the
         // bare mount still routes so a misaddressed request 404s through the
         // runtime handler instead of rendering a page at it.
         `  const requestPath = new URL(request.url).pathname;`,


### PR DESCRIPTION
## Summary

- Scripted server-function calls are moving to their own **data address**, `<endpoint>/data/<id>`, leaving the bare `<endpoint>/<id>` to plain HTTP (form actions, direct callers) — solidjs/solid#3094 (landed on `next` as solidjs/solid@95229453). The two caller kinds get differently shaped answers, and shared caches key on the URL, so the split keeps one caller kind's cached answer from ever being replayed to the other.
- The dev middleware's module-preload step assumed exactly one path segment after the mount, so a cold function only client code references would never be evaluated in the SSR environment for a data-addressed call — a 404 under `vite dev`. The id now parses from behind the literal `data` segment too. A function id spelled `data` still parses at the bare address, since an id occupies exactly one segment.
- Dispatch itself was already fine: mount matching is prefix-based, and the runtime handler accepts both address shapes. Comments on the mount gate updated to describe the two-address scheme.

Draft until a @solidjs/web carrying the data address ships (next release after 2.0.0-rc.4); safe to land early — the parsing change is additive.

## Test plan

- [ ] `pnpm build` (clean)
- [ ] Example e2e suites pass against current @solidjs/web (old client, bare addresses — unaffected path)
- [ ] After the next @solidjs/web release: `vite dev` against a client-only-referenced server function (cold SSR module) resolves at `/_server/data/<id>`

Made with [Cursor](https://cursor.com)