### PR TITLE
feat: observe option — observe build conditions + compiler componentNames

### DIFF
--- a/.changeset/observe-option.md
+++ b/.changeset/observe-option.md
@@ -1,0 +1,5 @@
+---
+'@solidjs/vite-plugin': patch
+---
+
+New `observe` option: resolve Solid's observe builds for production observability. `observe: true` adds the `observe` export condition to every environment — client and server, inlined and externalized (`resolve.externalConditions`), inlining the core runtime and its consumers for server builds the way the dev posture already does so one build is loaded end to end — and turns on the compiler's `componentNames` option, so component owner labels (`<Home>`) survive minification in diagnostics and attribution paths. `componentNames` is also enabled under the dev posture, where `lazy()` and HMR wrappers otherwise hide the tag name. Requires `@solidjs/compiler` / `@solidjs/babel-plugin` ≥ 2.0.0-rc.8 (the release that adds the option).

--- a/README.md
+++ b/README.md
@@ -125,6 +125,17 @@ This will inject `solid-js/dev` in place of `solid-js` in dev mode. Has no effec
 If set to false, it won't inject it in dev.
 This is useful for extra logs and debug.
 
+#### options.observe
+
+- Type: Boolean
+- Default: false
+
+Resolve Solid's observe builds in production: the production-speed runtime that keeps the
+diagnostics and attribution channels (`OBSERVE`) alive for observability tooling (error
+monitoring, performance tracing). Adds the `observe` export condition to every environment
+and turns on the compiler's `componentNames` option, so component owner labels (`<Home>`)
+survive minification. Under `vite dev` the dev build still wins.
+
 #### options.hot
 
 - Type: Boolean

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
   "dependencies": {
     "@ampproject/remapping": "^2.3.0",
     "@babel/core": "^7.23.3",
-    "@solidjs/babel-plugin": "^2.0.0-rc.6",
-    "@solidjs/compiler": "^2.0.0-rc.6",
+    "@solidjs/babel-plugin": "^2.0.0-rc.8",
+    "@solidjs/compiler": "^2.0.0-rc.8",
     "@types/babel__core": "^7.20.4",
     "merge-anything": "^5.1.7",
     "vitefu": "^1.0.4"
@@ -75,7 +75,7 @@
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@skypack/package-check": "^0.2.2",
-    "@solidjs/diagnostics": "^2.0.0-rc.3",
+    "@solidjs/diagnostics": "2.0.0-rc.8",
     "@solidjs/start-devtools": "^1.0.0-next.3",
     "@types/node": "^24.0.0",
     "cypress": "^14.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   default:
     '@solidjs/web':
-      specifier: ^2.0.0-rc.7
-      version: 2.0.0-rc.7
+      specifier: ^2.0.0-rc.8
+      version: 2.0.0-rc.8
     solid-js:
-      specifier: ^2.0.0-rc.7
-      version: 2.0.0-rc.7
+      specifier: ^2.0.0-rc.8
+      version: 2.0.0-rc.8
 
 importers:
 
@@ -24,14 +24,14 @@ importers:
         specifier: ^7.23.3
         version: 7.29.7
       '@solidjs/babel-plugin':
-        specifier: ^2.0.0-rc.6
-        version: 2.0.0-rc.7(@babel/core@7.29.7)(@tsrx/core@0.1.63)
+        specifier: ^2.0.0-rc.8
+        version: 2.0.0-rc.8(@babel/core@7.29.7)(@tsrx/core@0.1.63)
       '@solidjs/compiler':
-        specifier: ^2.0.0-rc.6
-        version: 2.0.0-rc.7
+        specifier: ^2.0.0-rc.8
+        version: 2.0.0-rc.8
       '@solidjs/web':
         specifier: ^2.0.0-rc.7
-        version: 2.0.0-rc.7(solid-js@2.0.0-rc.7)
+        version: 2.0.0-rc.8(solid-js@2.0.0-rc.8)
       '@testing-library/jest-dom':
         specifier: ^5.16.6 || ^5.17.0 || ^6.0.0 || ^7.0.0
         version: 6.10.0(@testing-library/dom@10.4.1)
@@ -67,11 +67,11 @@ importers:
         specifier: ^0.2.2
         version: 0.2.2
       '@solidjs/diagnostics':
-        specifier: ^2.0.0-rc.3
-        version: 2.0.0-rc.7(vitest@4.1.11)
+        specifier: 2.0.0-rc.8
+        version: 2.0.0-rc.8(vitest@4.1.11)
       '@solidjs/start-devtools':
         specifier: ^1.0.0-next.3
-        version: 1.0.0-next.4(@solidjs/web@2.0.0-rc.7(solid-js@2.0.0-rc.7))(solid-js@2.0.0-rc.7)
+        version: 1.0.0-next.4(@solidjs/web@2.0.0-rc.8(solid-js@2.0.0-rc.8))(solid-js@2.0.0-rc.8)
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.3
@@ -98,7 +98,7 @@ importers:
         version: 1.0.0(rollup@4.62.2)
       solid-js:
         specifier: ^2.0.0-rc.0
-        version: 2.0.0-rc.7
+        version: 2.0.0-rc.8
       typescript:
         specifier: ^5.2.2
         version: 5.9.3
@@ -110,10 +110,10 @@ importers:
     dependencies:
       '@solidjs/web':
         specifier: 'catalog:'
-        version: 2.0.0-rc.7(solid-js@2.0.0-rc.7)
+        version: 2.0.0-rc.8(solid-js@2.0.0-rc.8)
       solid-js:
         specifier: 'catalog:'
-        version: 2.0.0-rc.7
+        version: 2.0.0-rc.8
     devDependencies:
       '@solidjs/vite-plugin':
         specifier: workspace:*
@@ -126,10 +126,10 @@ importers:
     dependencies:
       '@solidjs/web':
         specifier: 'catalog:'
-        version: 2.0.0-rc.7(solid-js@2.0.0-rc.7)
+        version: 2.0.0-rc.8(solid-js@2.0.0-rc.8)
       solid-js:
         specifier: 'catalog:'
-        version: 2.0.0-rc.7
+        version: 2.0.0-rc.8
     devDependencies:
       '@solidjs/vite-plugin':
         specifier: workspace:*
@@ -142,10 +142,10 @@ importers:
     dependencies:
       '@solidjs/web':
         specifier: 'catalog:'
-        version: 2.0.0-rc.7(solid-js@2.0.0-rc.7)
+        version: 2.0.0-rc.8(solid-js@2.0.0-rc.8)
       solid-js:
         specifier: 'catalog:'
-        version: 2.0.0-rc.7
+        version: 2.0.0-rc.8
     devDependencies:
       '@solidjs/vite-plugin':
         specifier: workspace:*
@@ -158,10 +158,10 @@ importers:
     dependencies:
       '@solidjs/web':
         specifier: 'catalog:'
-        version: 2.0.0-rc.7(solid-js@2.0.0-rc.7)
+        version: 2.0.0-rc.8(solid-js@2.0.0-rc.8)
       solid-js:
         specifier: 'catalog:'
-        version: 2.0.0-rc.7
+        version: 2.0.0-rc.8
       valibot:
         specifier: ^1.1.0
         version: 1.4.2(typescript@5.9.3)
@@ -183,10 +183,10 @@ importers:
     dependencies:
       '@solidjs/web':
         specifier: 'catalog:'
-        version: 2.0.0-rc.7(solid-js@2.0.0-rc.7)
+        version: 2.0.0-rc.8(solid-js@2.0.0-rc.8)
       solid-js:
         specifier: 'catalog:'
-        version: 2.0.0-rc.7
+        version: 2.0.0-rc.8
     devDependencies:
       '@solidjs/vite-plugin':
         specifier: workspace:*
@@ -205,14 +205,14 @@ importers:
     dependencies:
       '@solidjs/web':
         specifier: 'catalog:'
-        version: 2.0.0-rc.7(solid-js@2.0.0-rc.7)
+        version: 2.0.0-rc.8(solid-js@2.0.0-rc.8)
       solid-js:
         specifier: 'catalog:'
-        version: 2.0.0-rc.7
+        version: 2.0.0-rc.8
     devDependencies:
       '@solidjs/testing-library':
         specifier: ^1.0.0-beta.2
-        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.7(solid-js@2.0.0-rc.7))(solid-js@2.0.0-rc.7)
+        version: 1.0.0-beta.2(@solidjs/web@2.0.0-rc.8(solid-js@2.0.0-rc.8))(solid-js@2.0.0-rc.8)
       '@solidjs/vite-plugin':
         specifier: workspace:*
         version: link:../..
@@ -1362,8 +1362,8 @@ packages:
     resolution: {integrity: sha512-T4Wyi9lUuz0a1C2OHuzqZ0aFOCI0AmaGTb2LP9sHgWdoHXlB3JU02gfBpa0Y081G/gFsJYpQ/R0iCJRzF/nknw==}
     hasBin: true
 
-  '@solidjs/babel-plugin@2.0.0-rc.7':
-    resolution: {integrity: sha512-cKcyVbOh8WC7ywV3txxfNrFRtTa7t8O3tXDXRf3RE3DKyZr+hZmbEOq6q/T6smaJXS3ekzuUDVlQrG1+HErnhg==}
+  '@solidjs/babel-plugin@2.0.0-rc.8':
+    resolution: {integrity: sha512-lh2TjYxozlIvMNJVzkJl8lUZ3xZvJORL1YTybbixmm4RU7bRaNDpiOcNiJx3fHIDwwTy4RwBXKQ7nqYDy5He9Q==}
     peerDependencies:
       '@babel/core': ^7.20.12
       '@tsrx/core': 0.1.63
@@ -1371,48 +1371,49 @@ packages:
       '@tsrx/core':
         optional: true
 
-  '@solidjs/compiler-darwin-arm64@2.0.0-rc.7':
-    resolution: {integrity: sha512-xJ7FoPrFV94LMuEPNJ2nIGFlqhVGR+s5GAr0nzMRMdWAimriF0sZ8clxlIqPS3v2oaNE9JW7EDCdJysD3JezWg==}
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.8':
+    resolution: {integrity: sha512-HWVgWLs1A9bUcdOtL2WUteTGmM4Bgb63J1htfxUt2BfstN1Of+X+QytaTYOG1U3cI9wcaHImryDNxgHkxqGLIA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@solidjs/compiler-darwin-x64@2.0.0-rc.7':
-    resolution: {integrity: sha512-rcu8wcxeO0QWXu69yFaSf3ZR1KlsPDCzmRmdA8fX/cte96Ox0r6GfMXE+5CH/gg9dSaXY3qwwmpSG9AEvLxZQg==}
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.8':
+    resolution: {integrity: sha512-d+XuMD9iUiE+p7l1xjF0tvatYcnhLBRcoHixGu38umTvGomZrpHypQLDDhY3baZIjlS/Pad0DzYN77TljySyrA==}
     cpu: [x64]
     os: [darwin]
 
-  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.7':
-    resolution: {integrity: sha512-EhiLKgLcFkHWYOx3Pds3px0onhTbzpDfenhsuDy1R7ViZYALXXBlZ+EUSE85rKwyCM0sgcR/kVMswL2V8sJXng==}
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.8':
+    resolution: {integrity: sha512-GT3TXzWb5MjfplsXNUYHzzCe2sNZM1MSDinkPC2Zpty7X1By34pHjvfdFi6yq0zsb6iQZhRnZz8L2a7NHwfkMg==}
     cpu: [arm64]
     os: [linux]
 
-  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.7':
-    resolution: {integrity: sha512-ymN3hIqzH3msWt3lcU3vqILnzRlB1rNbv1BlUqXkwVZByjFw/bJQ+BgncIq0WqNH6ciQ5nhZ1E7ECgGw/SNwEA==}
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.8':
+    resolution: {integrity: sha512-/0OsCDPhIijarLubxheHlHZ7sNZaWZQkRe4xwI9qf51aizXwz9Y0p4T4r4PudilnsfrqN+5ptUhtlmyfHDHs4A==}
     cpu: [x64]
     os: [linux]
 
-  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.7':
-    resolution: {integrity: sha512-k4vN+EHRtoIxj0D8d2VYHPEnWIok6kokbZskpn1pXrOoXBkj0OmqzzyJVBvSRYx6cWDWEjCKSWGuufRRZtgmjA==}
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.8':
+    resolution: {integrity: sha512-azFGpzpjhmTUfkKHkUg5M2QAmtC3HB+gP0DrSOYH+QzPT3T2XTixy+NOhNxrLD2UZiNLn9FoB3iARJzd3BSbdA==}
     engines: {node: '>=14.0.0'}
 
-  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.7':
-    resolution: {integrity: sha512-pZtrkWmiiZ/NRwyMASAitwAa4EO2jlt4z8Z5K9NoljnBreWrCsz4HmIKSIeZ+17++WwAyeZo2byon0AEv6FzRQ==}
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.8':
+    resolution: {integrity: sha512-qZbumMy5Qm3ilhgaBY/aozo//EWnd1Kk12j+MqQEMzeZlOrnCrLcFZg06DI0cldval5I9UsiKC33Vv+Sn1njAw==}
     cpu: [x64]
     os: [win32]
 
-  '@solidjs/compiler@2.0.0-rc.7':
-    resolution: {integrity: sha512-jhFq/QcoUM34760NuQiSvMDInZ+3AEHwA354VELRDpAJwuiMpPbEvkSH6qqfgneDzVwCiCtLbjScqUEymU7R1A==}
+  '@solidjs/compiler@2.0.0-rc.8':
+    resolution: {integrity: sha512-rjX98GSc5elXAdQU1N/LdYAITW46UW/nBZvx54NV9WOhaFKAsAA6vLMi3SuHMF9WCRRMikLs9+DjRK0ZHBtkfA==}
 
-  '@solidjs/diagnostics@2.0.0-rc.7':
-    resolution: {integrity: sha512-XppGGFRGc7dtX8i+eKn04A0+q2AGLdbTUbHqRhSRaN81aGHOAhMEeyXWzSoY9tABpPgy4jga1m9t4xz9FwAJzA==}
+  '@solidjs/diagnostics@2.0.0-rc.8':
+    resolution: {integrity: sha512-EjVbL6E1bf6xn52Tw5k1akvF8M/JV1UANH3RVn3am7qhro9VJYHwCSrkQGhLbI8iCyLcvt6MchuPKSuZHo9U5g==}
     peerDependencies:
       vitest: '>=2.0.0'
     peerDependenciesMeta:
       vitest:
         optional: true
 
-  '@solidjs/signals@2.0.0-rc.7':
-    resolution: {integrity: sha512-JY0OJ5nGeqxGKOAqCtuoHkFBkaWQYxmf+yBQE8vw/o9C7yUF+Kan9PwcrL0ZHR6+MgyixBUtTfBigwou5hwW5w==}
+  '@solidjs/signals@2.0.0-rc.8':
+    resolution: {integrity: sha512-EGk9WkxnlQtqdERjPgS8gvWVjKLZnBQr95e65FOAs9MqkxVhHIjgipan7svZZ6n0rkp6vSc9GxyeY836boaT6w==}
+    engines: {node: '>=22.12.0'}
 
   '@solidjs/start-devtools@1.0.0-next.4':
     resolution: {integrity: sha512-RNjndz1PfUicxJi3XHwjoIsu9AHeOhpP8Y/bgRmumR5Z9ymdMsiRCL89Fq1YqxhBnHf+GL4kX/VvC+F8lgmTVA==}
@@ -1427,10 +1428,11 @@ packages:
       '@solidjs/web': '>=2.0.0'
       solid-js: '>=2.0.0'
 
-  '@solidjs/web@2.0.0-rc.7':
-    resolution: {integrity: sha512-qsKKWR4PzzPw8ZGFR0Oc2776G1ONMMBKPJWO3Opf3cWHoczgfhknW6NED0WtdCuR6T8usFTWCZgMM5Cc0h14Dg==}
+  '@solidjs/web@2.0.0-rc.8':
+    resolution: {integrity: sha512-GeJEHtSjsbvRLpREfbQa5ksn6EuJKjxY/kXxuOP5Sn5FlXz6fuL3wHJr88PYlCOPV1KxxxWSc5h5jzKMKQQXDg==}
+    engines: {node: '>=22.12.0'}
     peerDependencies:
-      solid-js: ^2.0.0-rc.7
+      solid-js: ^2.0.0-rc.8
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2779,14 +2781,14 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  seroval-plugins@1.5.6:
-    resolution: {integrity: sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ==}
+  seroval-plugins@1.6.7:
+    resolution: {integrity: sha512-4Nk35ttD3DTDJW4hgw5StsVAPeU6qnDFnULAouw6tQ7oLTV/ICXrWpsXo2EE52eSP2joUMazbVf52mFEcADqRw==}
     engines: {node: '>=10'}
     peerDependencies:
       seroval: ^1.0
 
-  seroval@1.5.6:
-    resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
+  seroval@1.6.7:
+    resolution: {integrity: sha512-AeDcLh0yO2SFm9W71essgnSzLV9DI8ZH0x0knXn2DMnUZj728mpLbxjlbB6IqKCmqh8JA3cEqRyGoNkt584JcQ==}
     engines: {node: '>=10'}
 
   shebang-command@2.0.0:
@@ -2839,8 +2841,9 @@ packages:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
     engines: {node: '>=10'}
 
-  solid-js@2.0.0-rc.7:
-    resolution: {integrity: sha512-3APJcwGbJ3YzXzPXwl0R3cAiogXLacXdXSFasdE2uw1Gzj5xqDW/0bJu4fs75KK5WzXg+JfpkcsxBjTxkbnLQQ==}
+  solid-js@2.0.0-rc.8:
+    resolution: {integrity: sha512-0DwASKxvwXWAxCiea71cN3bmsyBIOUGmmg/pjSfhxPg+2pBVCh/ZKmwLNjKlPjc8SHeu52ZTio6tBBp1TcPB8A==}
+    engines: {node: '>=22.12.0'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -3031,9 +3034,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  validate-html-nesting@1.2.4:
-    resolution: {integrity: sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw==}
 
   verror@1.10.0:
     resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
@@ -4445,7 +4445,7 @@ snapshots:
       kleur: 4.1.5
       yargs-parser: 20.2.9
 
-  '@solidjs/babel-plugin@2.0.0-rc.7(@babel/core@7.29.7)(@tsrx/core@0.1.63)':
+  '@solidjs/babel-plugin@2.0.0-rc.8(@babel/core@7.29.7)(@tsrx/core@0.1.63)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.18.6
@@ -4453,65 +4453,64 @@ snapshots:
       '@babel/types': 7.29.8
       html-entities: 2.3.3
       parse5: 7.3.0
-      validate-html-nesting: 1.2.4
     optionalDependencies:
       '@tsrx/core': 0.1.63
 
-  '@solidjs/compiler-darwin-arm64@2.0.0-rc.7':
+  '@solidjs/compiler-darwin-arm64@2.0.0-rc.8':
     optional: true
 
-  '@solidjs/compiler-darwin-x64@2.0.0-rc.7':
+  '@solidjs/compiler-darwin-x64@2.0.0-rc.8':
     optional: true
 
-  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.7':
+  '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.8':
     optional: true
 
-  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.7':
+  '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.8':
     optional: true
 
-  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.7':
+  '@solidjs/compiler-wasm32-wasi@2.0.0-rc.8':
     dependencies:
       '@emnapi/core': 1.11.3
       '@emnapi/runtime': 1.11.3
       '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     optional: true
 
-  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.7':
+  '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.8':
     optional: true
 
-  '@solidjs/compiler@2.0.0-rc.7':
+  '@solidjs/compiler@2.0.0-rc.8':
     optionalDependencies:
-      '@solidjs/compiler-darwin-arm64': 2.0.0-rc.7
-      '@solidjs/compiler-darwin-x64': 2.0.0-rc.7
-      '@solidjs/compiler-linux-arm64-gnu': 2.0.0-rc.7
-      '@solidjs/compiler-linux-x64-gnu': 2.0.0-rc.7
-      '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.7
-      '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.7
+      '@solidjs/compiler-darwin-arm64': 2.0.0-rc.8
+      '@solidjs/compiler-darwin-x64': 2.0.0-rc.8
+      '@solidjs/compiler-linux-arm64-gnu': 2.0.0-rc.8
+      '@solidjs/compiler-linux-x64-gnu': 2.0.0-rc.8
+      '@solidjs/compiler-wasm32-wasi': 2.0.0-rc.8
+      '@solidjs/compiler-win32-x64-msvc': 2.0.0-rc.8
 
-  '@solidjs/diagnostics@2.0.0-rc.7(vitest@4.1.11)':
+  '@solidjs/diagnostics@2.0.0-rc.8(vitest@4.1.11)':
     dependencies:
-      '@solidjs/signals': 2.0.0-rc.7
+      '@solidjs/signals': 2.0.0-rc.8
     optionalDependencies:
       vitest: 4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(jsdom@26.1.0)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2))
 
-  '@solidjs/signals@2.0.0-rc.7': {}
+  '@solidjs/signals@2.0.0-rc.8': {}
 
-  '@solidjs/start-devtools@1.0.0-next.4(@solidjs/web@2.0.0-rc.7(solid-js@2.0.0-rc.7))(solid-js@2.0.0-rc.7)':
+  '@solidjs/start-devtools@1.0.0-next.4(@solidjs/web@2.0.0-rc.8(solid-js@2.0.0-rc.8))(solid-js@2.0.0-rc.8)':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.7(solid-js@2.0.0-rc.7)
-      solid-js: 2.0.0-rc.7
+      '@solidjs/web': 2.0.0-rc.8(solid-js@2.0.0-rc.8)
+      solid-js: 2.0.0-rc.8
 
-  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.7(solid-js@2.0.0-rc.7))(solid-js@2.0.0-rc.7)':
+  '@solidjs/testing-library@1.0.0-beta.2(@solidjs/web@2.0.0-rc.8(solid-js@2.0.0-rc.8))(solid-js@2.0.0-rc.8)':
     dependencies:
-      '@solidjs/web': 2.0.0-rc.7(solid-js@2.0.0-rc.7)
+      '@solidjs/web': 2.0.0-rc.8(solid-js@2.0.0-rc.8)
       '@testing-library/dom': 10.4.1
-      solid-js: 2.0.0-rc.7
+      solid-js: 2.0.0-rc.8
 
-  '@solidjs/web@2.0.0-rc.7(solid-js@2.0.0-rc.7)':
+  '@solidjs/web@2.0.0-rc.8(solid-js@2.0.0-rc.8)':
     dependencies:
-      seroval: 1.5.6
-      seroval-plugins: 1.5.6(seroval@1.5.6)
-      solid-js: 2.0.0-rc.7
+      seroval: 1.6.7
+      seroval-plugins: 1.6.7(seroval@1.6.7)
+      solid-js: 2.0.0-rc.8
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -5898,11 +5897,11 @@ snapshots:
 
   semver@7.8.5: {}
 
-  seroval-plugins@1.5.6(seroval@1.5.6):
+  seroval-plugins@1.6.7(seroval@1.6.7):
     dependencies:
-      seroval: 1.5.6
+      seroval: 1.6.7
 
-  seroval@1.5.6: {}
+  seroval@1.6.7: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -5964,12 +5963,12 @@ snapshots:
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
 
-  solid-js@2.0.0-rc.7:
+  solid-js@2.0.0-rc.8:
     dependencies:
-      '@solidjs/signals': 2.0.0-rc.7
+      '@solidjs/signals': 2.0.0-rc.8
       csstype: 3.2.3
-      seroval: 1.5.6
-      seroval-plugins: 1.5.6(seroval@1.5.6)
+      seroval: 1.6.7
+      seroval-plugins: 1.6.7(seroval@1.6.7)
 
   source-map-js@1.2.1: {}
 
@@ -6117,8 +6116,6 @@ snapshots:
   valibot@1.4.2(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
-
-  validate-html-nesting@1.2.4: {}
 
   verror@1.10.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,27 +8,27 @@ allowBuilds:
   msw: true
 
 catalog:
-  solid-js: "^2.0.0-rc.7"
-  "@solidjs/web": "^2.0.0-rc.7"
+  solid-js: "^2.0.0-rc.8"
+  "@solidjs/web": "^2.0.0-rc.8"
 
 ignoredBuiltDependencies:
   - cypress
 
 minimumReleaseAgeExclude:
-  - '@solidjs/signals@2.0.0-beta.30 || 2.0.0-beta.31 || 2.0.0-beta.32 || 2.0.0-rc.0 || 2.0.0-rc.1 || 2.0.0-rc.2 || 2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7'
+  - '@solidjs/signals@2.0.0-beta.30 || 2.0.0-beta.31 || 2.0.0-beta.32 || 2.0.0-rc.0 || 2.0.0-rc.1 || 2.0.0-rc.2 || 2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7 || 2.0.0-rc.8'
   - '@solidjs/start-devtools@1.0.0-next.1 || 1.0.0-next.2 || 1.0.0-next.3'
-  - '@solidjs/web@2.0.0-beta.30 || 2.0.0-beta.31 || 2.0.0-beta.32 || 2.0.0-rc.0 || 2.0.0-rc.1 || 2.0.0-rc.2 || 2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7'
-  - '@solidjs/babel-plugin@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7'
-  - '@solidjs/compiler@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7'
-  - '@solidjs/compiler-darwin-arm64@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7'
-  - '@solidjs/compiler-darwin-x64@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7'
-  - '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7'
-  - '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7'
-  - '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7'
-  - '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7'
-  - '@solidjs/diagnostics@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7'
+  - '@solidjs/web@2.0.0-beta.30 || 2.0.0-beta.31 || 2.0.0-beta.32 || 2.0.0-rc.0 || 2.0.0-rc.1 || 2.0.0-rc.2 || 2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7 || 2.0.0-rc.8'
+  - '@solidjs/babel-plugin@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7 || 2.0.0-rc.8'
+  - '@solidjs/compiler@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7 || 2.0.0-rc.8'
+  - '@solidjs/compiler-darwin-arm64@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7 || 2.0.0-rc.8'
+  - '@solidjs/compiler-darwin-x64@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7 || 2.0.0-rc.8'
+  - '@solidjs/compiler-linux-arm64-gnu@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7 || 2.0.0-rc.8'
+  - '@solidjs/compiler-linux-x64-gnu@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7 || 2.0.0-rc.8'
+  - '@solidjs/compiler-win32-x64-msvc@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7 || 2.0.0-rc.8'
+  - '@solidjs/compiler-wasm32-wasi@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7 || 2.0.0-rc.8'
+  - '@solidjs/diagnostics@2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7 || 2.0.0-rc.8'
   - '@tsrx/core@0.1.63'
-  - solid-js@2.0.0-beta.30 || 2.0.0-beta.31 || 2.0.0-beta.32 || 2.0.0-rc.0 || 2.0.0-rc.1 || 2.0.0-rc.2 || 2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7
+  - solid-js@2.0.0-beta.30 || 2.0.0-beta.31 || 2.0.0-beta.32 || 2.0.0-rc.0 || 2.0.0-rc.1 || 2.0.0-rc.2 || 2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7 || 2.0.0-rc.8
   - '@dom-expressions/babel-plugin-jsx@0.50.0-next.35 || 0.50.0-next.37 || 0.50.0-next.40 || 0.50.0-next.43'
   - '@dom-expressions/compiler-darwin-arm64@0.50.0-next.35 || 0.50.0-next.37 || 0.50.0-next.40 || 0.50.0-next.43'
   - '@dom-expressions/compiler-darwin-x64@0.50.0-next.35 || 0.50.0-next.37 || 0.50.0-next.40 || 0.50.0-next.43'

--- a/src/index.ts
+++ b/src/index.ts
@@ -237,6 +237,18 @@ export interface Options {
    */
   dev?: boolean;
   /**
+   * Resolve Solid's observe builds: the production-speed runtime that keeps
+   * the diagnostics and attribution channels (`OBSERVE`) alive for
+   * production observability tooling. Adds the `observe` export condition
+   * to every environment (client and server, inlined and externalized) and
+   * turns on the compiler's `componentNames` option so owner labels survive
+   * minification. Applies to `vite build` and preview; under `vite dev` the
+   * `development` condition still wins (the dev build is a superset).
+   *
+   * @default false
+   */
+  observe?: boolean;
+  /**
    * Dev-serve only: expose Solid's diagnostic and attribution channels to
    * out-of-process consumers (agents, tests, curl). Injects a client module
    * that installs the in-page bridge from the app's own
@@ -498,6 +510,7 @@ function getSolidOptions(
   options: Partial<Options>,
   isSsr: boolean,
   dev: boolean,
+  observe: boolean,
   isTestMode = false,
 ): SolidOptions {
   let solidOptions: Pick<SolidOptions, 'generate' | 'hydratable'>;
@@ -537,10 +550,17 @@ function getSolidOptions(
   // builtIns, contextToCustomElements, wrapConditionals) are baked into both
   // backends — @solidjs/compiler and @solidjs/babel-plugin — so only the
   // posture this plugin actually decides is passed.
+  // Component labels: the dev and observe runtimes name each component's
+  // owner (`<Home>`) for diagnostics and attribution paths. Without the
+  // compiler carrying the source tag name, a minified build labels owners by
+  // whatever the minifier left of `Comp.name`. DOM-only by construction (the
+  // ssr generate ignores the flag), and the production runtime ignores the
+  // argument, so it is only emitted for the postures whose runtime reads it.
   return {
     ...solidOptions,
     ...(serverComponents && solidOptions.generate === 'ssr' ? { serverComponents: true } : {}),
     dev,
+    ...(dev || observe ? { componentNames: true } : {}),
     ...(options.solid || {}),
   };
 }
@@ -864,6 +884,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
 
   let needHmr = false;
   let replaceDev = false;
+  let observe = false;
   // Resolved absolute path of the start-mode document shell (normalized to
   // forward slashes, matching Vite ids), reported back by the start plugin's
   // config hook. The document is the one module whose client compile must
@@ -998,7 +1019,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
   }
 
   async function compileTsrxCss(source: string, id: string): Promise<string> {
-    const solidOptions = getSolidOptions(options, false, replaceDev, isTestMode);
+    const solidOptions = getSolidOptions(options, false, replaceDev, observe, isTestMode);
     if (options.compiler === 'babel') {
       const babelUserOptions = await getBabelUserOptions(options, source, id, false);
       const babelOptions = mergeAndConcat(babelUserOptions, {
@@ -1036,6 +1057,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
     async config(userConfig, { command }) {
       // We inject the dev mode only if the user explicitly wants it or if we are in dev (serve) mode
       replaceDev = options.dev === true || (options.dev !== false && command === 'serve');
+      observe = options.observe === true;
       projectRoot = userConfig.root || projectRoot;
       isTestMode = userConfig.mode === 'test';
       // Per-vitest-project posture: the client posture (browser conditions,
@@ -1077,9 +1099,12 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
         // Semi-framework is the right class: `ssr.noExternal` without
         // `optimizeDeps.exclude`, since these hold no raw Solid components.
         isSemiFrameworkPkgByJson(pkgJson) {
-          // Same gate as the core inlining in configEnvironment: dev serve
-          // only, never vitest (it manages inlining via test.server.deps).
-          if (!replaceDev || isTestMode) return false;
+          // Same gate as the core inlining in configEnvironment: dev serve or
+          // an observe build (the `observe` condition selects a server build
+          // the same way `development` does, and an externalized consumer
+          // would split it just the same), never vitest (it manages inlining
+          // via test.server.deps).
+          if (!(replaceDev || observe) || isTestMode) return false;
           return SOLID_RUNTIME_PKGS.some(
             (name) => pkgJson.dependencies?.[name] || pkgJson.peerDependencies?.[name],
           );
@@ -1180,7 +1205,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
                   if (!isTsrxModule(id) || isTsrxCssModule(id)) return null;
                   const compiler = await loadNativeCompiler();
                   const result = await compiler.transformAsync(source, {
-                    ...getSolidOptions(options, false, replaceDev, isTestMode),
+                    ...getSolidOptions(options, false, replaceDev, observe, isTestMode),
                     filename: cleanModuleId(id),
                     sourceMap: false,
                   });
@@ -1212,6 +1237,10 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
       config.resolve.conditions = [
         'solid',
         ...(replaceDev ? ['development'] : []),
+        // `development` nests above `observe` in the runtime's exports, so
+        // both may be present: dev serve keeps the dev build, builds get the
+        // observe build.
+        ...(observe ? ['observe'] : []),
         // Tests resolve the browser builds even when the app is
         // server-rendered — the client posture applies to the whole test
         // pipeline, not just the codegen. Projects that explicitly opt into
@@ -1231,10 +1260,13 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
       // runtime among them) run their PRODUCTION copy under `vite dev`:
       // server errors reach the client sanitized to "Internal Server Error"
       // instead of carrying the real message, dev-only diagnostics vanish.
-      // So the dev flag has to reach both lists.
-      if (replaceDev && config.consumer !== 'client' && name !== 'client') {
+      // So the dev flag has to reach both lists — and `observe` selects its
+      // server build the same way, with the same split if it only reaches
+      // one list.
+      if ((replaceDev || observe) && config.consumer !== 'client' && name !== 'client') {
         config.resolve.externalConditions = [
-          'development',
+          ...(replaceDev ? ['development'] : []),
+          ...(observe ? ['observe'] : []),
           ...(config.resolve.externalConditions ?? defaultExternalConditions),
         ];
 
@@ -1553,7 +1585,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
       }
 
       const inNodeModules = /node_modules/.test(id);
-      const solidOptions = getSolidOptions(options, !!isSsr, replaceDev, isTestMode);
+      const solidOptions = getSolidOptions(options, !!isSsr, replaceDev, observe, isTestMode);
 
       // We need to know if the current file extension has a typescript options tied to it
       const shouldBeProcessedWithTypescript =


### PR DESCRIPTION
## Summary

New `observe: true` option for production observability builds:

- Adds the `observe` export condition to every environment — client and server, `resolve.conditions` and `resolve.externalConditions` — and inlines the core runtime (and its consumers, via the semi-framework crawl) for server builds, the same way the dev posture does, so one build is loaded end to end rather than the app's `solid-js` resolving the observe build while an externalized consumer's `import "solid-js"` lands on Node's prod copy.
- Turns on the compiler's `componentNames` option, so component owner labels (`<Home>`) survive minification in diagnostic `ownerPath`s and attribution chains. The dev posture also gets `componentNames` (a `lazy()` or HMR wrapper otherwise hides the tag name).
- Under `vite dev` the `development` condition still wins (solid-js nests it above `observe`).

Verified on a Sentry adapter spike: with the local plugin and compilers linked, a minified `vite build` resolves the observe runtime and reports `<Router> › … › <Layout> › … › <Show> › … › <For>` instead of mangled names.

## Gating

Depended on solidjs/solid#3340 (`componentNames` in `@solidjs/compiler` / `@solidjs/babel-plugin`), released in Solid `2.0.0-rc.8`. The second commit rides rc.8 (catalog, release-age excludes, lockfile) and requires `@solidjs/compiler` / `@solidjs/babel-plugin` `^2.0.0-rc.8`, since an older compiler rejects the unknown option. Verified against the published rc.8: the vite-8 example (cypress) passes, and an `observe: true` build of it emits `createComponent(Count, {}, "Count")` on the observe runtime. Ready for review.

Co-authored with Claude via Cursor.

