### PR TITLE
fix: allow @testing-library/jest-dom v7 on the next line

### DIFF
--- a/.changeset/jest-dom-v7-next.md
+++ b/.changeset/jest-dom-v7-next.md
@@ -1,0 +1,5 @@
+---
+'@solidjs/vite-plugin': patch
+---
+
+Allow `@testing-library/jest-dom` v7 in the optional peer dependency range (ports #287 from `main`). The Solid 2.0 templates pin `@testing-library/jest-dom@^7.0.0`, and npm 7+ enforces peer ranges, so a clean `npm install` of a freshly created project failed with `ERESOLVE` against the `^6.*` range (solidjs/solid#3341). v7 keeps the `@testing-library/jest-dom/vitest` subpath the plugin auto-injects into `test.setupFiles`, so only the range changes.

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "peerDependencies": {
     "@solidjs/start-devtools": "^1.0.0-next.2",
     "@solidjs/web": "^2.0.0-rc.7",
-    "@testing-library/jest-dom": "^5.16.6 || ^5.17.0 || ^6.*",
+    "@testing-library/jest-dom": "^5.16.6 || ^5.17.0 || ^6.0.0 || ^7.0.0",
     "solid-js": "^2.0.0-rc.7",
     "vite": "^8.0.0 || ^9.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
         specifier: ^2.0.0-rc.7
         version: 2.0.0-rc.7(solid-js@2.0.0-rc.7)
       '@testing-library/jest-dom':
-        specifier: ^5.16.6 || ^5.17.0 || ^6.*
+        specifier: ^5.16.6 || ^5.17.0 || ^6.0.0 || ^7.0.0
         version: 6.10.0(@testing-library/dom@10.4.1)
       '@types/babel__core':
         specifier: ^7.20.4


### PR DESCRIPTION
Ports #287 (merged to `main` as 2.11.14) to the `next` line.

## Problem

`@solidjs/vite-plugin@3.0.0-next.41` declares `peerOptional @testing-library/jest-dom: "^5.16.6 || ^5.17.0 || ^6.*"`. The Solid 2.0 templates moved to `@testing-library/jest-dom@^7.0.0` (solidjs/templates#302), and npm 7+ hard-fails on peer conflicts, so a clean `npm install` of a project freshly created by `npm init solid@latest` errors with `ERESOLVE`. pnpm only warns, which is why the templates repo itself installs fine.

Fixes solidjs/solid#3341.

## Fix

Widen the optional peer range to `^5.16.6 || ^5.17.0 || ^6.0.0 || ^7.0.0`, same as #287. No code change: v7 keeps the `@testing-library/jest-dom/vitest` subpath that `getJestDomExport` auto-injects into `test.setupFiles`. The lockfile diff is the one-line specifier update.

## Verification

Reproduced the `ERESOLVE` with the published next.41 on a fresh `with-tailwindcss` copy under npm 11, then swapped in a tarball built from this branch: `npm install` succeeds (jest-dom 7.0.1 resolved) and the template's `vitest run` passes with the plugin-injected jest-dom setup.

---
Authored by Claude via Cursor.

Made with [Cursor](https://cursor.com)