### PR TITLE
fix: honor the host's noExternal patterns when adding vitefu's SSR externals

### DIFF
--- a/.changeset/honor-host-noexternal-patterns.md
+++ b/.changeset/honor-host-noexternal-patterns.md
@@ -1,0 +1,5 @@
+---
+'@solidjs/vite-plugin': patch
+---
+
+Honor the host's `resolve.noExternal` patterns when adding vitefu's externals to the SSR environment. The plugin already refused to re-externalize anything `noExternal` inlines, but it compared literal names only, while Vite treats string entries as picomatch patterns and RegExp entries as tests (`createFilter(undefined, noExternal, { resolve: false })`). Since 3.0.0-next.41 the crawl also reaches the packages that consume the Solid runtime, and their non-Solid dependencies land in `ssr.external` — so a host that inlines its packages by pattern (TanStack Start's `@tanstack/start**`, whose `@tanstack/start-server-core` resolves its `#tanstack-*` imports only when Vite processes it) saw them re-externalized, and `vite dev` failed with `ERR_PACKAGE_IMPORT_NOT_DEFINED: Package import specifier "#tanstack-router-entry" is not defined`. The externals are now filtered with the same matcher Vite uses, and a single string or RegExp `noExternal` value is kept instead of being dropped.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1270,8 +1270,13 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
       // Only set resolve.external if noExternal is not true (to avoid conflicts with plugins like Cloudflare)
       if (name === 'ssr' && solidPkgsConfig) {
         if (config.resolve.noExternal !== true) {
+          const hostNoExternal = config.resolve.noExternal;
           const noExternal = [
-            ...(Array.isArray(config.resolve.noExternal) ? config.resolve.noExternal : []),
+            ...(Array.isArray(hostNoExternal)
+              ? hostNoExternal
+              : hostNoExternal
+                ? [hostNoExternal]
+                : []),
             ...solidPkgsConfig.ssr.noExternal,
           ];
           config.resolve.noExternal = noExternal;
@@ -1282,9 +1287,25 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin[] {
           // @tanstack/solid-router 2.0.0-rc.7 → @solidjs/web) would therefore
           // re-externalize a core inlined above and split the runtime again.
           // Nothing inlined may appear in `external`.
+          //
+          // "Inlined" means whatever `noExternal` claims, judged the way Vite
+          // judges it (`createFilter(undefined, noExternal, { resolve:
+          // false })` in its `createIsConfiguredAsExternal`): string entries
+          // are picomatch patterns, RegExp entries test the id. A literal
+          // `includes` check only caught exact names, so a host that inlines
+          // its packages by pattern — TanStack Start's `@tanstack/start**`,
+          // whose start-server-core resolves `#tanstack-*` imports only when
+          // Vite processes it — saw them re-externalized once the
+          // semi-framework crawl reached them through its Solid adapter
+          // (their non-Solid dependencies land in vitefu's `ssr.external`),
+          // and `vite dev` failed with ERR_PACKAGE_IMPORT_NOT_DEFINED.
+          const keepsExternal =
+            noExternal.length > 0
+              ? createFilter(undefined, noExternal, { resolve: false })
+              : () => true;
           config.resolve.external = [
             ...(Array.isArray(config.resolve.external) ? config.resolve.external : []),
-            ...solidPkgsConfig.ssr.external.filter((dep) => !noExternal.includes(dep)),
+            ...solidPkgsConfig.ssr.external.filter((dep) => keepsExternal(dep)),
           ];
         }
       }


### PR DESCRIPTION
## Problem

`configEnvironment` for the `ssr` environment appends vitefu's `ssr.external` to `resolve.external`, filtering out anything the merged `noExternal` list inlines — but with a literal `noExternal.includes(dep)` check. Vite judges `noExternal` differently: string entries are picomatch patterns and RegExp entries are tests (`createFilter(undefined, noExternal, { resolve: false })` in `createIsConfiguredAsExternal`), and `external` takes precedence over `noExternal`.

Since 3.0.0-next.41 the crawl also classifies packages that consume the Solid runtime as semi-framework, so their non-Solid dependencies now land in `ssr.external`. A host that inlines its packages by pattern gets them externalized anyway. Concretely, TanStack Start sets `resolve.noExternal: ['@tanstack/start**', '@tanstack/solid-start**']`; `@tanstack/solid-start` depends on solid-js, so `@tanstack/start-server-core`, `start-client-core`, `start-plugin-core` and `start-storage-context` were added to `external`. Those packages import `#tanstack-router-entry` and friends, which only Vite's plugin pipeline can resolve, so every `vite dev` SSR request failed:

```
TypeError [ERR_PACKAGE_IMPORT_NOT_DEFINED]: Package import specifier "#tanstack-router-entry" is not defined in package …/@tanstack/start-server-core/package.json
```

Resolved `environments.ssr.resolve.external` for a TanStack Start Solid app on next.42:

```
["@babel/core","@jridgewell/remapping","@nothing-but/utils","@solidjs/babel-plugin","@solidjs/compiler","@tanstack/history","@tanstack/router-core","@tanstack/start-client-core","@tanstack/start-plugin-core","@tanstack/start-server-core","@tanstack/start-storage-context","isbot","pathe","seroval","seroval-plugins"]
```

## Fix

Filter vitefu's externals with the same matcher Vite uses for `noExternal` (`createFilter(undefined, noExternal, { resolve: false })`), so pattern and RegExp entries are honored. While there, a single string or RegExp `noExternal` value is normalized into the merged list instead of being dropped.

Same app with this patch (TanStack's own workaround plugin removed):

```
["@babel/core","@jridgewell/remapping","@nothing-but/utils","@solidjs/babel-plugin","@solidjs/compiler","@tanstack/history","@tanstack/router-core","isbot","pathe","seroval","seroval-plugins"]
```

`vite dev` SSR answers 200 again. Context: TanStack/router#8348 (the rc.7 / next.42 bump), which carries a host-side guard until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
